### PR TITLE
시청을 비롯한 건물 구현

### DIFF
--- a/Assets/Prefabs/Managers/UI Manager.prefab
+++ b/Assets/Prefabs/Managers/UI Manager.prefab
@@ -1215,7 +1215,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.00012207031, y: 0}
+  m_AnchoredPosition: {x: 0.00024414062, y: 0}
   m_SizeDelta: {x: 0, y: 300}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &6905652389645462716
@@ -11912,7 +11912,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 7923277162799115181}
   m_HandleRect: {fileID: 4892613928390725156}
   m_Direction: 0
-  m_Value: 0.000000047683706
+  m_Value: -0.00000009536743
   m_Size: 0
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -13594,10 +13594,12 @@ MonoBehaviour:
   _currentDayInfo: {fileID: 1281846309816490731}
   _timeTillRiseSlider: {fileID: 8953165364860055070}
   _timeTillRiseSliderInfo: {fileID: 6757136963023271671}
+  _woodText: {fileID: 2212991857018225532}
   _woodInfo: {fileID: 3600510155588217058}
+  _stoneText: {fileID: 2039405686204472278}
   _stoneInfo: {fileID: 93108637350195475}
-  _researchInfo: {fileID: 5380247459934615478}
   _researchText: {fileID: 4048562789785410286}
+  _researchInfo: {fileID: 5380247459934615478}
 --- !u!1 &7221446371420249465
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Managers/UI Manager.prefab
+++ b/Assets/Prefabs/Managers/UI Manager.prefab
@@ -33,7 +33,7 @@ RectTransform:
   m_Father: {fileID: 5348416877541007473}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -1091,6 +1091,81 @@ MonoBehaviour:
   _resumeButton: {fileID: 1111086415499562438}
   _quitButton: {fileID: 8719057371496662485}
   _quitIcon: {fileID: 6545785908579579578}
+--- !u!1 &677826901869116773
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6338004392705940136}
+  - component: {fileID: 8485939506410647885}
+  - component: {fileID: 3922119930237941812}
+  m_Layer: 5
+  m_Name: Research Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6338004392705940136
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 677826901869116773}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2631555383593947356}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 10, y: 0}
+  m_SizeDelta: {x: 45, y: 45}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &8485939506410647885
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 677826901869116773}
+  m_CullTransparentMesh: 1
+--- !u!114 &3922119930237941812
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 677826901869116773}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &776055238179104105
 GameObject:
   m_ObjectHideFlags: 0
@@ -1140,7 +1215,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0.00018310547, y: 0}
+  m_AnchoredPosition: {x: -0.00012207031, y: 0}
   m_SizeDelta: {x: 0, y: 300}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &6905652389645462716
@@ -1323,6 +1398,140 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _quitIcon: {fileID: 5168041918686184443}
+--- !u!1 &952223308189890559
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8715071347700264517}
+  - component: {fileID: 7279946897103334641}
+  - component: {fileID: 4048562789785410286}
+  m_Layer: 5
+  m_Name: Research Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8715071347700264517
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 952223308189890559}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2631555383593947356}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 70, y: 0}
+  m_SizeDelta: {x: 150, y: 50}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &7279946897103334641
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 952223308189890559}
+  m_CullTransparentMesh: 1
+--- !u!114 &4048562789785410286
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 952223308189890559}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 100%
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: bc0c3be559d99444ca47c6b077b7e531, type: 2}
+  m_sharedMaterial: {fileID: -5292969587588953101, guid: bc0c3be559d99444ca47c6b077b7e531, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 32
+  m_fontSizeBase: 32
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &959935146195646925
 GameObject:
   m_ObjectHideFlags: 0
@@ -2712,7 +2921,7 @@ RectTransform:
   m_Father: {fileID: 4334054699130022170}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 40, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -5412,6 +5621,97 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3382968947826858837
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2631555383593947356}
+  - component: {fileID: 9108926232802618254}
+  - component: {fileID: 5380247459934615478}
+  - component: {fileID: 2883672037443727717}
+  m_Layer: 5
+  m_Name: Research Info
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2631555383593947356
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3382968947826858837}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6338004392705940136}
+  - {fileID: 8715071347700264517}
+  m_Father: {fileID: 5650799196877412818}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 925, y: 0}
+  m_SizeDelta: {x: 145, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9108926232802618254
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3382968947826858837}
+  m_CullTransparentMesh: 1
+--- !u!114 &5380247459934615478
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3382968947826858837}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates: []
+--- !u!114 &2883672037443727717
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3382968947826858837}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &3394720188308070288
 GameObject:
   m_ObjectHideFlags: 0
@@ -6162,95 +6462,6 @@ RectTransform:
   m_AnchoredPosition: {x: -5, y: 0}
   m_SizeDelta: {x: -20, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &3650859878928107185
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8602792420159195313}
-  - component: {fileID: 713204590745360776}
-  - component: {fileID: 437188481138553448}
-  - component: {fileID: 5844529856280457474}
-  m_Layer: 5
-  m_Name: Game State Icon
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &8602792420159195313
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3650859878928107185}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5650799196877412818}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 860, y: 0}
-  m_SizeDelta: {x: 45, y: 45}
-  m_Pivot: {x: 0, y: 0.5}
---- !u!222 &713204590745360776
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3650859878928107185}
-  m_CullTransparentMesh: 1
---- !u!114 &437188481138553448
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3650859878928107185}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Delegates: []
---- !u!114 &5844529856280457474
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3650859878928107185}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &3671388357190699469
 GameObject:
   m_ObjectHideFlags: 0
@@ -6651,7 +6862,7 @@ RectTransform:
   m_Father: {fileID: 3382621437916671781}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -10008,7 +10219,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 930, y: 0}
+  m_AnchoredPosition: {x: 1040, y: 0}
   m_SizeDelta: {x: 45, y: 45}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &6877518819530621364
@@ -11701,7 +11912,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 7923277162799115181}
   m_HandleRect: {fileID: 4892613928390725156}
   m_Direction: 0
-  m_Value: -0.000000047683713
+  m_Value: 0.000000047683706
   m_Size: 0
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -13319,14 +13530,14 @@ RectTransform:
   - {fileID: 2061609171675783347}
   - {fileID: 6656723021885049806}
   - {fileID: 7968477677846493751}
-  - {fileID: 8602792420159195313}
+  - {fileID: 2631555383593947356}
   - {fileID: 186690790314015225}
   m_Father: {fileID: 9122111369357036391}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 32, y: -32}
-  m_SizeDelta: {x: 995, y: 80}
+  m_SizeDelta: {x: 1105, y: 80}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &6514604103711787439
 CanvasRenderer:
@@ -13385,7 +13596,8 @@ MonoBehaviour:
   _timeTillRiseSliderInfo: {fileID: 6757136963023271671}
   _woodInfo: {fileID: 3600510155588217058}
   _stoneInfo: {fileID: 93108637350195475}
-  _gameStateInfo: {fileID: 437188481138553448}
+  _researchInfo: {fileID: 5380247459934615478}
+  _researchText: {fileID: 4048562789785410286}
 --- !u!1 &7221446371420249465
 GameObject:
   m_ObjectHideFlags: 0
@@ -17082,7 +17294,7 @@ RectTransform:
   m_Father: {fileID: 2977417052857975629}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 40, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -474,6 +474,28 @@ MonoBehaviour:
   m_DeselectOnBackgroundClick: 1
   m_PointerBehavior: 0
   m_CursorLockBehavior: 0
+--- !u!114 &1376913556 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2039405686204472278, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
+  m_PrefabInstance: {fileID: 3193284147619751300}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1424760378 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2212991857018225532, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
+  m_PrefabInstance: {fileID: 3193284147619751300}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2400213661275808771
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -608,6 +630,18 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1771634902617427013, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1771634902617427013, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1771634902617427013, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2035092001804752556, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -736,6 +770,14 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4604655113903486287, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
+      propertyPath: _woodText
+      value: 
+      objectReference: {fileID: 1424760378}
+    - target: {fileID: 4604655113903486287, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
+      propertyPath: _stoneText
+      value: 
+      objectReference: {fileID: 1376913556}
     - target: {fileID: 4794776392540175359, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -870,7 +912,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8470437041877012436, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -1595.5143
+      value: 0.00024414062
       objectReference: {fileID: 0}
     - target: {fileID: 9122111369357036391, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
       propertyPath: m_Pivot.x

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -596,10 +596,6 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 415149029236557644, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 1053405786408036947, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
       propertyPath: m_Size
       value: 1
@@ -612,22 +608,6 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1771634902617427013, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1771634902617427013, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1771634902617427013, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2015026912939948117, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 2035092001804752556, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -674,10 +654,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2846474644702685880, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2848237675673411386, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
-      propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3097392440976543652, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
@@ -894,11 +870,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8470437041877012436, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -0.00012207031
-      objectReference: {fileID: 0}
-    - target: {fileID: 8577273620853853418, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
+      value: -1595.5143
       objectReference: {fileID: 0}
     - target: {fileID: 9122111369357036391, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
       propertyPath: m_Pivot.x

--- a/Assets/Scripts/Game/BuildState.cs
+++ b/Assets/Scripts/Game/BuildState.cs
@@ -73,6 +73,10 @@ public class BuildState : MonoBehaviour
                 if (StructureManager.Instance.CheckStructureValidity(tile, _structureToBuild))
                 {
                     tile.CreateStructure(_structureToBuild);
+
+                    GameManager.Instance.CurrentWoods -= StructureManager.Instance.GetStructureData(_structureToBuild).WoodCost;
+                    GameManager.Instance.CurrentStones -= StructureManager.Instance.GetStructureData(_structureToBuild).StoneCost;
+
                     GameManager.Instance.ChangeGameState(GameState.None);
                 }
             }

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -14,6 +14,7 @@ public class GameManager : SingletonBehaviour<GameManager>
 {
     private const float OCEAN_RISE_PERIOD = 300f;
     private const float DAY_SPEED = 9.6f;
+    private const int MAX_RESEARCH_POINT = 100;
 
     [SerializeField] private MonoBehaviour[] _gameStates;
 
@@ -92,6 +93,23 @@ public class GameManager : SingletonBehaviour<GameManager>
     [SerializeField] private int _currentStones = 999;
 
     /// <summary>
+    /// 현재 연구 포인트
+    /// </summary>
+    public int CurrentResearchPoint
+    {
+        get => _currentResearchPoint;
+    }
+    private int _currentResearchPoint = 0;
+
+    /// <summary>
+    /// 최대 연구 포인트
+    /// </summary>
+    public int MaxResearchPoint
+    {
+        get => MAX_RESEARCH_POINT;
+    }
+
+    /// <summary>
     /// 맵에 시청이 있는지 여부
     /// </summary>
     public bool HasTownHall
@@ -161,5 +179,14 @@ public class GameManager : SingletonBehaviour<GameManager>
         {
             (_gameStates[1] as BuildState).SetStructureToBuild((StructureType)structure);
         }
+    }
+
+    /// <summary>
+    /// 현재 연구 포인트를 amount 값만큼 변경한다.
+    /// </summary>
+    /// <param name="amount">변경할 값</param>
+    public void ChangeResearchPoint(int amount)
+    {
+        _currentResearchPoint = Mathf.Clamp(_currentResearchPoint + amount, 0, MAX_RESEARCH_POINT);
     }
 }

--- a/Assets/Scripts/Structures/ScriptableObjects/Apartment.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Apartment.asset
@@ -44,6 +44,6 @@ MonoBehaviour:
   StoneCost: 2
   Radius: 2
   MaxHappiness: 100
-  IncreaseSpeed: 0
-  DecreaseSpeed: 0
+  IncreaseSpeed: 10
+  DecreaseSpeed: 3.333
   TimeToProduce: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/Apartment.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Apartment.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2a2d7f3515ce7c24594c96283012cf88, type: 3}
   m_Name: Apartment
   m_EditorClassIdentifier: 
-  StructureType: 0
+  StructureType: 2
   StructureImage: {fileID: 0}
   StructureNameKey: apartment_title
   StructurePrefab: {fileID: 9073670328388804027, guid: f912e0e7ee62574428fa7fd817a4ccf5, type: 3}
@@ -39,6 +39,7 @@ MonoBehaviour:
     clothe: 0
     efficiencyBonus: 0
     radiusBonus: 0
+  RequireOcean: 0
   WoodCost: 2
   StoneCost: 2
   Radius: 2

--- a/Assets/Scripts/Structures/ScriptableObjects/Dock.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Dock.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2a2d7f3515ce7c24594c96283012cf88, type: 3}
   m_Name: Dock
   m_EditorClassIdentifier: 
-  StructureType: 1
+  StructureType: 8
   StructureImage: {fileID: 0}
   StructureNameKey: dock_title
   StructurePrefab: {fileID: 9073670328388804027, guid: 3f863f2fae4f9654fbb348c6087ff2e3, type: 3}

--- a/Assets/Scripts/Structures/ScriptableObjects/Farm.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Farm.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2a2d7f3515ce7c24594c96283012cf88, type: 3}
   m_Name: Farm
   m_EditorClassIdentifier: 
-  StructureType: 1
+  StructureType: 9
   StructureImage: {fileID: 0}
   StructureNameKey: farm_title
   StructurePrefab: {fileID: 9073670328388804027, guid: 3f863f2fae4f9654fbb348c6087ff2e3, type: 3}
@@ -39,6 +39,7 @@ MonoBehaviour:
     clothe: 0
     efficiencyBonus: 0
     radiusBonus: 0
+  RequireOcean: 0
   WoodCost: 2
   StoneCost: 0
   Radius: 2

--- a/Assets/Scripts/Structures/ScriptableObjects/Fortress.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Fortress.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2a2d7f3515ce7c24594c96283012cf88, type: 3}
   m_Name: Fortress
   m_EditorClassIdentifier: 
-  StructureType: 0
+  StructureType: 13
   StructureImage: {fileID: 0}
   StructureNameKey: fortress_title
   StructurePrefab: {fileID: 9073670328388804027, guid: 3f863f2fae4f9654fbb348c6087ff2e3, type: 3}
@@ -39,6 +39,7 @@ MonoBehaviour:
     clothe: 0
     efficiencyBonus: 1
     radiusBonus: 0
+  RequireOcean: 0
   WoodCost: 2
   StoneCost: 0
   Radius: 3

--- a/Assets/Scripts/Structures/ScriptableObjects/Fortress.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Fortress.asset
@@ -44,6 +44,6 @@ MonoBehaviour:
   StoneCost: 0
   Radius: 3
   MaxHappiness: 100
-  IncreaseSpeed: 0
-  DecreaseSpeed: 0
+  IncreaseSpeed: 10
+  DecreaseSpeed: 3.333
   TimeToProduce: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/House.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/House.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2a2d7f3515ce7c24594c96283012cf88, type: 3}
   m_Name: House
   m_EditorClassIdentifier: 
-  StructureType: 0
+  StructureType: 1
   StructureImage: {fileID: 0}
   StructureNameKey: house_title
   StructurePrefab: {fileID: 9073670328388804027, guid: 3f863f2fae4f9654fbb348c6087ff2e3, type: 3}
@@ -39,6 +39,7 @@ MonoBehaviour:
     clothe: 0
     efficiencyBonus: 0
     radiusBonus: 0
+  RequireOcean: 0
   WoodCost: 2
   StoneCost: 0
   Radius: 1

--- a/Assets/Scripts/Structures/ScriptableObjects/House.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/House.asset
@@ -44,6 +44,6 @@ MonoBehaviour:
   StoneCost: 0
   Radius: 1
   MaxHappiness: 100
-  IncreaseSpeed: 0
-  DecreaseSpeed: 0
+  IncreaseSpeed: 10
+  DecreaseSpeed: 3.333
   TimeToProduce: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/HydroponicsFarm.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/HydroponicsFarm.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2a2d7f3515ce7c24594c96283012cf88, type: 3}
   m_Name: HydroponicsFarm
   m_EditorClassIdentifier: 
-  StructureType: 1
+  StructureType: 10
   StructureImage: {fileID: 0}
   StructureNameKey: hydroponics_farm_title
   StructurePrefab: {fileID: 9073670328388804027, guid: 3f863f2fae4f9654fbb348c6087ff2e3, type: 3}
@@ -39,6 +39,7 @@ MonoBehaviour:
     clothe: 0
     efficiencyBonus: 0
     radiusBonus: 0
+  RequireOcean: 0
   WoodCost: 2
   StoneCost: 2
   Radius: 2

--- a/Assets/Scripts/Structures/ScriptableObjects/LumberCamp.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/LumberCamp.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2a2d7f3515ce7c24594c96283012cf88, type: 3}
   m_Name: LumberCamp
   m_EditorClassIdentifier: 
-  StructureType: 1
+  StructureType: 5
   StructureImage: {fileID: 0}
   StructureNameKey: lumber_camp_title
   StructurePrefab: {fileID: 9073670328388804027, guid: 3f863f2fae4f9654fbb348c6087ff2e3, type: 3}
@@ -39,6 +39,7 @@ MonoBehaviour:
     clothe: 0
     efficiencyBonus: 0
     radiusBonus: 0
+  RequireOcean: 0
   WoodCost: 2
   StoneCost: 0
   Radius: 2

--- a/Assets/Scripts/Structures/ScriptableObjects/Market.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Market.asset
@@ -39,10 +39,11 @@ MonoBehaviour:
     clothe: 0
     efficiencyBonus: 0
     radiusBonus: 3
+  RequireOcean: 0
   WoodCost: 2
   StoneCost: 2
   Radius: 3
   MaxHappiness: 100
-  IncreaseSpeed: 0
-  DecreaseSpeed: 0
+  IncreaseSpeed: 10
+  DecreaseSpeed: 3.333
   TimeToProduce: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/Pier.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Pier.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2a2d7f3515ce7c24594c96283012cf88, type: 3}
   m_Name: Pier
   m_EditorClassIdentifier: 
-  StructureType: 1
+  StructureType: 7
   StructureImage: {fileID: 0}
   StructureNameKey: pier_title
   StructurePrefab: {fileID: 9073670328388804027, guid: 3f863f2fae4f9654fbb348c6087ff2e3, type: 3}

--- a/Assets/Scripts/Structures/ScriptableObjects/Quarry.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Quarry.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2a2d7f3515ce7c24594c96283012cf88, type: 3}
   m_Name: Quarry
   m_EditorClassIdentifier: 
-  StructureType: 1
+  StructureType: 6
   StructureImage: {fileID: 0}
   StructureNameKey: quarry_title
   StructurePrefab: {fileID: 9073670328388804027, guid: 3f863f2fae4f9654fbb348c6087ff2e3, type: 3}
@@ -39,6 +39,7 @@ MonoBehaviour:
     clothe: 0
     efficiencyBonus: 0
     radiusBonus: 0
+  RequireOcean: 0
   WoodCost: 2
   StoneCost: 0
   Radius: 2

--- a/Assets/Scripts/Structures/ScriptableObjects/Restaurant.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Restaurant.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2a2d7f3515ce7c24594c96283012cf88, type: 3}
   m_Name: Restaurant
   m_EditorClassIdentifier: 
-  StructureType: 1
+  StructureType: 11
   StructureImage: {fileID: 0}
   StructureNameKey: restaurant_title
   StructurePrefab: {fileID: 9073670328388804027, guid: 3f863f2fae4f9654fbb348c6087ff2e3, type: 3}
@@ -21,7 +21,7 @@ MonoBehaviour:
   SunkenStructurePrefab: {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
   Needs:
     population: 1
-    fish: 0
+    fish: 1
     food: 0
     wood: 0
     stone: 0
@@ -39,6 +39,7 @@ MonoBehaviour:
     clothe: 0
     efficiencyBonus: 0
     radiusBonus: 0
+  RequireOcean: 0
   WoodCost: 2
   StoneCost: 0
   Radius: 2

--- a/Assets/Scripts/Structures/ScriptableObjects/School.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/School.asset
@@ -44,6 +44,6 @@ MonoBehaviour:
   StoneCost: 2
   Radius: 3
   MaxHappiness: 100
-  IncreaseSpeed: 0
-  DecreaseSpeed: 0
+  IncreaseSpeed: 10
+  DecreaseSpeed: 3.333
   TimeToProduce: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/School.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/School.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2a2d7f3515ce7c24594c96283012cf88, type: 3}
   m_Name: School
   m_EditorClassIdentifier: 
-  StructureType: 0
+  StructureType: 4
   StructureImage: {fileID: 0}
   StructureNameKey: school_title
   StructurePrefab: {fileID: 9073670328388804027, guid: d6fe6e57057151a44a94ae3bb9106c0b, type: 3}
@@ -39,6 +39,7 @@ MonoBehaviour:
     clothe: 0
     efficiencyBonus: 1
     radiusBonus: 0
+  RequireOcean: 0
   WoodCost: 2
   StoneCost: 2
   Radius: 3

--- a/Assets/Scripts/Structures/ScriptableObjects/TextileMill.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/TextileMill.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2a2d7f3515ce7c24594c96283012cf88, type: 3}
   m_Name: TextileMill
   m_EditorClassIdentifier: 
-  StructureType: 1
+  StructureType: 12
   StructureImage: {fileID: 0}
   StructureNameKey: textile_mill_title
   StructurePrefab: {fileID: 9073670328388804027, guid: 3f863f2fae4f9654fbb348c6087ff2e3, type: 3}
@@ -25,7 +25,7 @@ MonoBehaviour:
     food: 0
     wood: 0
     stone: 0
-    cotton: 0
+    cotton: 1
     clothe: 0
     efficiencyBonus: 0
     radiusBonus: 0
@@ -39,6 +39,7 @@ MonoBehaviour:
     clothe: 0
     efficiencyBonus: 0
     radiusBonus: 0
+  RequireOcean: 0
   WoodCost: 2
   StoneCost: 0
   Radius: 2

--- a/Assets/Scripts/Structures/ScriptableObjects/TownHall.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/TownHall.asset
@@ -39,10 +39,11 @@ MonoBehaviour:
     clothe: 0
     efficiencyBonus: 0
     radiusBonus: 0
+  RequireOcean: 0
   WoodCost: 4
   StoneCost: 4
   Radius: 0
   MaxHappiness: 100
-  IncreaseSpeed: 0
-  DecreaseSpeed: 0
+  IncreaseSpeed: 10
+  DecreaseSpeed: 3.333
   TimeToProduce: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/TownHall.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/TownHall.asset
@@ -46,4 +46,4 @@ MonoBehaviour:
   MaxHappiness: 100
   IncreaseSpeed: 10
   DecreaseSpeed: 3.333
-  TimeToProduce: 0
+  TimeToProduce: 30

--- a/Assets/Scripts/Structures/Structure.cs
+++ b/Assets/Scripts/Structures/Structure.cs
@@ -221,6 +221,20 @@ public class ActiveProducerStructure : Structure
             if (_elapsed > _structureData.TimeToProduce)
             {
                 _elapsed -= _structureData.TimeToProduce;
+
+                switch (_structureData.StructureType)
+                {
+                    case StructureType.TownHall:
+                        GameManager.Instance.ChangeResearchPoint(1);
+                        break;
+                    case StructureType.LumberCamp:
+                        GameManager.Instance.CurrentWoods += 3; ;
+                        break;
+                    case StructureType.Quarry:
+                        GameManager.Instance.CurrentStones += 3;
+                        break;
+                }
+
                 Debug.Log("Produced Something");
             }
         }

--- a/Assets/Scripts/Structures/StructureManager.cs
+++ b/Assets/Scripts/Structures/StructureManager.cs
@@ -97,6 +97,7 @@ public class StructureManager : SingletonBehaviour<StructureManager>
     {
         switch (type)
         {
+            case StructureType.TownHall:
             case StructureType.LumberCamp:
             case StructureType.Quarry:
                 return true;

--- a/Assets/Scripts/Structures/StructureManager.cs
+++ b/Assets/Scripts/Structures/StructureManager.cs
@@ -37,7 +37,21 @@ public class StructureManager : SingletonBehaviour<StructureManager>
     /// <returns>건물 클래스</returns>
     public Structure GetStructure(StructureType type, Tile tile)
     {
-        Structure structure = IsConsumer(type) ? new ConsumerStructure() : new ProducerStructure();
+        Structure structure;
+
+        if (IsConsumer(type))
+        {
+            structure = new ConsumerStructure();
+        }
+        else if (IsActiveProducer(type))
+        {
+            structure = new ActiveProducerStructure();
+        }
+        else
+        {
+            structure = new PassiveProducerStructure();
+        }
+
         structure.Initialize(type, tile);
 
         return structure;
@@ -67,6 +81,24 @@ public class StructureManager : SingletonBehaviour<StructureManager>
             case StructureType.Market:
             case StructureType.School:
             case StructureType.Fortress:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// 능동 생산형 건물 여부를 확인한다.
+    /// </summary>
+    /// <param name="type">건물 종류</param>
+    /// <returns>능동 생산형 건물인 경우</returns>
+    public bool IsActiveProducer(StructureType type)
+    {
+        switch (type)
+        {
+            case StructureType.LumberCamp:
+            case StructureType.Quarry:
                 return true;
 
             default:

--- a/Assets/Scripts/UI/ConfirmMenuUI.cs
+++ b/Assets/Scripts/UI/ConfirmMenuUI.cs
@@ -27,6 +27,9 @@ public class ConfirmMenuUI : MonoBehaviour
         _descriptionText.ChangeKey(description);
         _descriptionText.UpdateTextLanguage();
 
+        _confirmButton.onClick.RemoveAllListeners();
+        _cancelButton.onClick.RemoveAllListeners();
+
         _confirmButton.onClick.AddListener(() => { UIManager.Instance.HideConfirmMenu(true); });
         _cancelButton.onClick.AddListener(() => { UIManager.Instance.HideConfirmMenu(false); });
 

--- a/Assets/Scripts/UI/GameInfoUI.cs
+++ b/Assets/Scripts/UI/GameInfoUI.cs
@@ -18,7 +18,8 @@ public class GameInfoUI : MonoBehaviour
     [SerializeField] private EventTrigger _timeTillRiseSliderInfo;
     [SerializeField] private EventTrigger _woodInfo;
     [SerializeField] private EventTrigger _stoneInfo;
-    [SerializeField] private EventTrigger _gameStateInfo;
+    [SerializeField] private EventTrigger _researchInfo;
+    [SerializeField] private TMP_Text _researchText;
 
     void Start()
     {
@@ -28,13 +29,14 @@ public class GameInfoUI : MonoBehaviour
         UIManager.Instance.AddHoverEvent(_timeTillRiseSliderInfo, "option_title", "language_label", HoverDirection.TopLeft);
         UIManager.Instance.AddHoverEvent(_woodInfo, "option_title", "language_label", HoverDirection.TopLeft);
         UIManager.Instance.AddHoverEvent(_stoneInfo, "option_title", "language_label", HoverDirection.TopLeft);
-        UIManager.Instance.AddHoverEvent(_gameStateInfo, "option_title", "language_label", HoverDirection.TopLeft);
+        UIManager.Instance.AddHoverEvent(_researchInfo, "option_title", "language_label", HoverDirection.TopLeft);
     }
 
     private void Update()
     {
         _currentDayText.text = "DAY " + GameManager.Instance.CurrentDay;
         _timeTillRiseSlider.value = GameManager.Instance.TimeSinceOceanRise / GameManager.Instance.OceanRisePeriod;
+        _researchText.text = (int)((float)GameManager.Instance.CurrentResearchPoint / GameManager.Instance.MaxResearchPoint * 100) + "%";
     }
 
     void OnMainMenuOpen()

--- a/Assets/Scripts/UI/GameInfoUI.cs
+++ b/Assets/Scripts/UI/GameInfoUI.cs
@@ -12,14 +12,20 @@ using UnityEngine.UI;
 public class GameInfoUI : MonoBehaviour
 {
     [SerializeField] private Button _mainMenuButton;
+
     [SerializeField] private TMP_Text _currentDayText;
     [SerializeField] private EventTrigger _currentDayInfo;
+
     [SerializeField] private Slider _timeTillRiseSlider;
     [SerializeField] private EventTrigger _timeTillRiseSliderInfo;
+
+    [SerializeField] private TMP_Text _woodText;
     [SerializeField] private EventTrigger _woodInfo;
+    [SerializeField] private TMP_Text _stoneText;
     [SerializeField] private EventTrigger _stoneInfo;
-    [SerializeField] private EventTrigger _researchInfo;
+
     [SerializeField] private TMP_Text _researchText;
+    [SerializeField] private EventTrigger _researchInfo;
 
     void Start()
     {
@@ -36,6 +42,10 @@ public class GameInfoUI : MonoBehaviour
     {
         _currentDayText.text = "DAY " + GameManager.Instance.CurrentDay;
         _timeTillRiseSlider.value = GameManager.Instance.TimeSinceOceanRise / GameManager.Instance.OceanRisePeriod;
+
+        _woodText.text = GameManager.Instance.CurrentWoods.ToString();
+        _stoneText.text = GameManager.Instance.CurrentStones.ToString();
+
         _researchText.text = (int)((float)GameManager.Instance.CurrentResearchPoint / GameManager.Instance.MaxResearchPoint * 100) + "%";
     }
 

--- a/Assets/Scripts/UI/TileInfoUI.cs
+++ b/Assets/Scripts/UI/TileInfoUI.cs
@@ -9,6 +9,9 @@ using UnityEngine.UI;
 /// </summary>
 public class TileInfoUI : MonoBehaviour
 {
+    private const int RESEARCH_COST_WOODS = 3;
+    private const int RESEARCH_COST_STONES = 3;
+
     [SerializeField] private GameObject _structureButtonPrefab;
 
     [Header("Title")]
@@ -72,6 +75,18 @@ public class TileInfoUI : MonoBehaviour
             UIManager.Instance.ShowConfirmMenu("language_label", "language_label", _currentTile.DestroyStructure, null);
         });
 
+        _researchButton.onClick.AddListener(() =>
+        {
+            UIManager.Instance.ShowConfirmMenu("language_label", "language_label", () =>
+            {
+                GameManager.Instance.CurrentWoods -= RESEARCH_COST_WOODS;
+                GameManager.Instance.CurrentStones -= RESEARCH_COST_STONES;
+
+                GameManager.Instance.ChangeResearchPoint(1);
+            },
+            null);
+        });
+
         UIManager.Instance.AddHoverEvent(_happinessInfo, "language_label", "language_label", HoverDirection.TopRight);
         UIManager.Instance.AddHoverEvent(_timeToProduceInfo, "language_label", "language_label", HoverDirection.TopRight);
         UIManager.Instance.AddHoverEvent(_researchInfo, "language_label", "language_label", HoverDirection.TopRight);
@@ -104,6 +119,11 @@ public class TileInfoUI : MonoBehaviour
             }
             else if (_currentTile.Structure is ActiveProducerStructure)
             {
+                if (_currentTile.Structure.StructureData.StructureType == StructureType.TownHall)
+                {
+                    _researchButton.interactable = GameManager.Instance.CurrentWoods >= RESEARCH_COST_WOODS && GameManager.Instance.CurrentStones >= RESEARCH_COST_STONES;
+                }
+
                 _gaugeSlider.value = (_currentTile.Structure as ActiveProducerStructure).Elapsed / _currentTile.Structure.StructureData.TimeToProduce;
                 _gaugeText.text = (_currentTile.Structure as ActiveProducerStructure).Elapsed + " / " + _currentTile.Structure.StructureData.TimeToProduce;
             }

--- a/Assets/Scripts/UI/TileInfoUI.cs
+++ b/Assets/Scripts/UI/TileInfoUI.cs
@@ -72,7 +72,14 @@ public class TileInfoUI : MonoBehaviour
 
         _destroyButton.onClick.AddListener(() =>
         {
-            UIManager.Instance.ShowConfirmMenu("language_label", "language_label", _currentTile.DestroyStructure, null);
+            UIManager.Instance.ShowConfirmMenu("language_label", "language_label", () =>
+            {
+                GameManager.Instance.CurrentWoods += _currentTile.Structure.StructureData.WoodCost / 2;
+                GameManager.Instance.CurrentStones += _currentTile.Structure.StructureData.StoneCost / 2;
+
+                _currentTile.DestroyStructure();
+            },
+            null);
         });
 
         _researchButton.onClick.AddListener(() =>

--- a/Assets/Scripts/UI/TileInfoUI.cs
+++ b/Assets/Scripts/UI/TileInfoUI.cs
@@ -115,7 +115,7 @@ public class TileInfoUI : MonoBehaviour
             if (_currentTile.Structure is ConsumerStructure)
             {
                 _gaugeSlider.value = (_currentTile.Structure as ConsumerStructure).CurrentHappiness / _currentTile.Structure.StructureData.MaxHappiness;
-                _gaugeText.text = (_currentTile.Structure as ConsumerStructure).CurrentHappiness + " / " + _currentTile.Structure.StructureData.MaxHappiness;
+                _gaugeText.text = (int)(_currentTile.Structure as ConsumerStructure).CurrentHappiness + " / " + (int)_currentTile.Structure.StructureData.MaxHappiness;
             }
             else if (_currentTile.Structure is ActiveProducerStructure)
             {
@@ -125,7 +125,7 @@ public class TileInfoUI : MonoBehaviour
                 }
 
                 _gaugeSlider.value = (_currentTile.Structure as ActiveProducerStructure).Elapsed / _currentTile.Structure.StructureData.TimeToProduce;
-                _gaugeText.text = (_currentTile.Structure as ActiveProducerStructure).Elapsed + " / " + _currentTile.Structure.StructureData.TimeToProduce;
+                _gaugeText.text = (int)(_currentTile.Structure as ActiveProducerStructure).Elapsed + " / " + (int)_currentTile.Structure.StructureData.TimeToProduce;
             }
         }
     }

--- a/Assets/Scripts/UI/TileInfoUI.cs
+++ b/Assets/Scripts/UI/TileInfoUI.cs
@@ -1,4 +1,5 @@
 using TMPro;
+using UnityEditor.Experimental.GraphView;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
@@ -101,10 +102,10 @@ public class TileInfoUI : MonoBehaviour
                 _gaugeSlider.value = (_currentTile.Structure as ConsumerStructure).CurrentHappiness / _currentTile.Structure.StructureData.MaxHappiness;
                 _gaugeText.text = (_currentTile.Structure as ConsumerStructure).CurrentHappiness + " / " + _currentTile.Structure.StructureData.MaxHappiness;
             }
-            else if (_currentTile.Structure is ProducerStructure)
+            else if (_currentTile.Structure is ActiveProducerStructure)
             {
-                _gaugeSlider.value = (_currentTile.Structure as ProducerStructure).Elapsed / _currentTile.Structure.StructureData.TimeToProduce;
-                _gaugeText.text = (_currentTile.Structure as ProducerStructure).Elapsed + " / " + _currentTile.Structure.StructureData.TimeToProduce;
+                _gaugeSlider.value = (_currentTile.Structure as ActiveProducerStructure).Elapsed / _currentTile.Structure.StructureData.TimeToProduce;
+                _gaugeText.text = (_currentTile.Structure as ActiveProducerStructure).Elapsed + " / " + _currentTile.Structure.StructureData.TimeToProduce;
             }
         }
     }
@@ -181,7 +182,7 @@ public class TileInfoUI : MonoBehaviour
             _gaugeText.gameObject.SetActive(true);
         }
         // 생산형 건물인 경우
-        else 
+        else if (_currentTile.Structure is ActiveProducerStructure)
         {
             // 시청인 경우
             if (_currentTile.Structure.StructureData.StructureType == StructureType.TownHall)
@@ -204,6 +205,17 @@ public class TileInfoUI : MonoBehaviour
 
             _gaugeSlider.gameObject.SetActive(true);
             _gaugeText.gameObject.SetActive(true);
+        }
+        else
+        {
+            _happinessInfo.gameObject.SetActive(false);
+            _timeToProduceInfo.gameObject.SetActive(false);
+            _researchInfo.gameObject.SetActive(false);
+
+            _researchButton.gameObject.SetActive(false);
+
+            _gaugeSlider.gameObject.SetActive(false);
+            _gaugeText.gameObject.SetActive(false);
         }
 
         _destroyButton.gameObject.SetActive(true);

--- a/Assets/Scripts/UI/TileInfoUI.cs
+++ b/Assets/Scripts/UI/TileInfoUI.cs
@@ -74,8 +74,16 @@ public class TileInfoUI : MonoBehaviour
         {
             UIManager.Instance.ShowConfirmMenu("language_label", "language_label", () =>
             {
-                GameManager.Instance.CurrentWoods += _currentTile.Structure.StructureData.WoodCost / 2;
-                GameManager.Instance.CurrentStones += _currentTile.Structure.StructureData.StoneCost / 2;
+                if (_currentTile.Structure != null)
+                {
+                    GameManager.Instance.CurrentWoods += _currentTile.Structure.StructureData.WoodCost / 2;
+                    GameManager.Instance.CurrentStones += _currentTile.Structure.StructureData.StoneCost / 2;
+                }
+                else
+                {
+                    GameManager.Instance.CurrentWoods += StructureManager.Instance.GetStructureData(StructureType.Deck).WoodCost / 2;
+                    GameManager.Instance.CurrentStones += StructureManager.Instance.GetStructureData(StructureType.Deck).StoneCost / 2;
+                }
 
                 _currentTile.DestroyStructure();
             },


### PR DESCRIPTION
### 관련 이슈
- #3
- #13

### 구현 사항
- 각 건물의 ScriptableObject 값을 설정했습니다.
- `ProducerStructure`를 `ActiveProducerStructure`와 `PassiveProducerStructure`로 분리했습니다.
  - `ActiveProducerStructure`: 일정 시간마다 자원을 생성합니다. (예: 시청, 벌목장, 채석장)
  - `PassiveProducerStructure`: 요구 사항이 충족되면 주변 타일에 자원을 제공합니다. (예: 식당, 방직소)
  - 각 생산형 건물의 생산 로직을 구현했습니다.
- `GameManager`에 연구 포인트와 관련된 변수와 메소드를 추가했습니다.
  - `CurrentResearchPoint`: 현재 연구 포인트.
  - `MaxResearchPoint`: 최대 연구 포인트.
  - `ChangeResearchPoint(int)`: 주어진 값만큼 연구 포인트를 증가, 감소시킵니다.
- 게임 정보 UI가 목재, 석재 소지량을 표시하도록 했습니다.
- 건물을 건설하면 자원을 소모하고, 파괴하면 일부를 돌려받도록 했습니다.
- 시청의 타일 메뉴에서, 자원을 소모해 연구 포인트를 증가시킬 수 있도록 했습니다.
- 확인 메뉴의 버튼 리스너가 제대로 갱신되지 않던 문제를 수정했습니다.