### PR TITLE
해적 시스템 구현

### DIFF
--- a/Assets/Materials/Ocean/StylizedWater.shadergraph
+++ b/Assets/Materials/Ocean/StylizedWater.shadergraph
@@ -2251,7 +2251,7 @@
     "m_AllowMaterialOverride": false,
     "m_SurfaceType": 1,
     "m_ZTestMode": 4,
-    "m_ZWriteControl": 0,
+    "m_ZWriteControl": 1,
     "m_AlphaMode": 0,
     "m_RenderFace": 2,
     "m_AlphaClip": false,

--- a/Assets/Materials/Test/LitShader.shadergraph
+++ b/Assets/Materials/Test/LitShader.shadergraph
@@ -1,0 +1,772 @@
+{
+    "m_SGVersion": 3,
+    "m_Type": "UnityEditor.ShaderGraph.GraphData",
+    "m_ObjectId": "b1b3233cdfac433db28bfdbc541ecb2b",
+    "m_Properties": [
+        {
+            "m_Id": "1deddba431334cbabe6ee8fa6c2ae2da"
+        }
+    ],
+    "m_Keywords": [],
+    "m_Dropdowns": [],
+    "m_CategoryData": [
+        {
+            "m_Id": "5fb7f23ea21f40f3a0c2844fd6d4dca6"
+        }
+    ],
+    "m_Nodes": [
+        {
+            "m_Id": "9335f4f2502241f4bf3b08e4cea887a1"
+        },
+        {
+            "m_Id": "60806258082e434c974cab6d5658f234"
+        },
+        {
+            "m_Id": "b4476a86c96d44659c7a9c8a451fbfbf"
+        },
+        {
+            "m_Id": "87ea4235a96848b991ded1b9674f8ce6"
+        },
+        {
+            "m_Id": "7fb766ccf5ee43788875a3821cf3f1c4"
+        },
+        {
+            "m_Id": "32115e4f83f44f0696d5ec6fb85d86ab"
+        },
+        {
+            "m_Id": "9548580b92494047a0f0fdcf860b515c"
+        },
+        {
+            "m_Id": "8ed2cbb59a214585aa78e36e7b449d6a"
+        },
+        {
+            "m_Id": "750118b8752b4885aa57f0faf5fc2ea5"
+        },
+        {
+            "m_Id": "c65b2256936344d888d486a31efb3a97"
+        }
+    ],
+    "m_GroupDatas": [],
+    "m_StickyNoteDatas": [],
+    "m_Edges": [
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "c65b2256936344d888d486a31efb3a97"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "87ea4235a96848b991ded1b9674f8ce6"
+                },
+                "m_SlotId": 0
+            }
+        }
+    ],
+    "m_VertexContext": {
+        "m_Position": {
+            "x": 0.0,
+            "y": 0.0
+        },
+        "m_Blocks": [
+            {
+                "m_Id": "9335f4f2502241f4bf3b08e4cea887a1"
+            },
+            {
+                "m_Id": "60806258082e434c974cab6d5658f234"
+            },
+            {
+                "m_Id": "b4476a86c96d44659c7a9c8a451fbfbf"
+            }
+        ]
+    },
+    "m_FragmentContext": {
+        "m_Position": {
+            "x": 0.0,
+            "y": 200.0
+        },
+        "m_Blocks": [
+            {
+                "m_Id": "87ea4235a96848b991ded1b9674f8ce6"
+            },
+            {
+                "m_Id": "7fb766ccf5ee43788875a3821cf3f1c4"
+            },
+            {
+                "m_Id": "32115e4f83f44f0696d5ec6fb85d86ab"
+            },
+            {
+                "m_Id": "9548580b92494047a0f0fdcf860b515c"
+            },
+            {
+                "m_Id": "8ed2cbb59a214585aa78e36e7b449d6a"
+            },
+            {
+                "m_Id": "750118b8752b4885aa57f0faf5fc2ea5"
+            }
+        ]
+    },
+    "m_PreviewData": {
+        "serializedMesh": {
+            "m_SerializedMesh": "{\"mesh\":{\"instanceID\":0}}",
+            "m_Guid": ""
+        },
+        "preventRotation": false
+    },
+    "m_Path": "Shader Graphs",
+    "m_GraphPrecision": 1,
+    "m_PreviewMode": 2,
+    "m_OutputNode": {
+        "m_Id": ""
+    },
+    "m_SubDatas": [],
+    "m_ActiveTargets": [
+        {
+            "m_Id": "44a377dadf0745a5b8a412b940a6b2d1"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.NormalMaterialSlot",
+    "m_ObjectId": "183fa59b33874cf5b53547b45daaedd7",
+    "m_Id": 0,
+    "m_DisplayName": "Normal (Tangent Space)",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "NormalTS",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 3
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "1d7ef70be29044f186223e3335067173",
+    "m_Id": 0,
+    "m_DisplayName": "Color",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 3,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.ColorShaderProperty",
+    "m_ObjectId": "1deddba431334cbabe6ee8fa6c2ae2da",
+    "m_Guid": {
+        "m_GuidSerialized": "a8f0eb81-ad37-4dd3-bde7-d87e5c7e764b"
+    },
+    "m_Name": "Color",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "Color",
+    "m_DefaultReferenceName": "_Color",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": {
+        "r": 0.0,
+        "g": 0.0,
+        "b": 0.0,
+        "a": 0.0
+    },
+    "isMainColor": false,
+    "m_ColorMode": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "32115e4f83f44f0696d5ec6fb85d86ab",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.Metallic",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "b05b92a0843c4cb984d4339b15108ac7"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Metallic"
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalTarget",
+    "m_ObjectId": "44a377dadf0745a5b8a412b940a6b2d1",
+    "m_Datas": [],
+    "m_ActiveSubTarget": {
+        "m_Id": "b509356982b64cd0a3f563a9983bab1b"
+    },
+    "m_AllowMaterialOverride": false,
+    "m_SurfaceType": 0,
+    "m_ZTestMode": 4,
+    "m_ZWriteControl": 1,
+    "m_AlphaMode": 0,
+    "m_RenderFace": 2,
+    "m_AlphaClip": false,
+    "m_CastShadows": true,
+    "m_ReceiveShadows": true,
+    "m_SupportsLODCrossFade": false,
+    "m_CustomEditorGUI": "",
+    "m_SupportVFX": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "5fb7f23ea21f40f3a0c2844fd6d4dca6",
+    "m_Name": "",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "1deddba431334cbabe6ee8fa6c2ae2da"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "60806258082e434c974cab6d5658f234",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Normal",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "6359813dc43f4c55a6bc5de296344931"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Normal"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.ColorRGBMaterialSlot",
+    "m_ObjectId": "60f802efb3fc49b0bc348f886dde08c5",
+    "m_Id": 0,
+    "m_DisplayName": "Emission",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Emission",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_ColorMode": 1,
+    "m_DefaultColor": {
+        "r": 0.0,
+        "g": 0.0,
+        "b": 0.0,
+        "a": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.NormalMaterialSlot",
+    "m_ObjectId": "6359813dc43f4c55a6bc5de296344931",
+    "m_Id": 0,
+    "m_DisplayName": "Normal",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Normal",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "750118b8752b4885aa57f0faf5fc2ea5",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.Occlusion",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "c1b1dbd9104f4bc1b86d72bab5de14de"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Occlusion"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "7fb766ccf5ee43788875a3821cf3f1c4",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.NormalTS",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "183fa59b33874cf5b53547b45daaedd7"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.NormalTS"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "87ea4235a96848b991ded1b9674f8ce6",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.BaseColor",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "8abd51f8c7a54bcd912a9841d381190f"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.BaseColor"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.ColorRGBMaterialSlot",
+    "m_ObjectId": "8abd51f8c7a54bcd912a9841d381190f",
+    "m_Id": 0,
+    "m_DisplayName": "Base Color",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "BaseColor",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.5,
+        "y": 0.5,
+        "z": 0.5
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_ColorMode": 0,
+    "m_DefaultColor": {
+        "r": 0.5,
+        "g": 0.5,
+        "b": 0.5,
+        "a": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "8ed2cbb59a214585aa78e36e7b449d6a",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.Emission",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "60f802efb3fc49b0bc348f886dde08c5"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Emission"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "9335f4f2502241f4bf3b08e4cea887a1",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Position",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "ff809610946241b7b0fc05865dad1bd6"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Position"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "9548580b92494047a0f0fdcf860b515c",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.Smoothness",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "d3be27e4106a4f0ca2eefccb634010e1"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Smoothness"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "b05b92a0843c4cb984d4339b15108ac7",
+    "m_Id": 0,
+    "m_DisplayName": "Metallic",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Metallic",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "b4476a86c96d44659c7a9c8a451fbfbf",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Tangent",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "df231331c991426bafbf06d174991359"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Tangent"
+}
+
+{
+    "m_SGVersion": 2,
+    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalLitSubTarget",
+    "m_ObjectId": "b509356982b64cd0a3f563a9983bab1b",
+    "m_WorkflowMode": 1,
+    "m_NormalDropOffSpace": 0,
+    "m_ClearCoat": false,
+    "m_BlendModePreserveSpecular": true
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "c1b1dbd9104f4bc1b86d72bab5de14de",
+    "m_Id": 0,
+    "m_DisplayName": "Ambient Occlusion",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Occlusion",
+    "m_StageCapability": 2,
+    "m_Value": 1.0,
+    "m_DefaultValue": 1.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "c65b2256936344d888d486a31efb3a97",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -311.0,
+            "y": 238.0,
+            "width": 105.0,
+            "height": 34.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "1d7ef70be29044f186223e3335067173"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "1deddba431334cbabe6ee8fa6c2ae2da"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "d3be27e4106a4f0ca2eefccb634010e1",
+    "m_Id": 0,
+    "m_DisplayName": "Smoothness",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Smoothness",
+    "m_StageCapability": 2,
+    "m_Value": 0.5,
+    "m_DefaultValue": 0.5,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.TangentMaterialSlot",
+    "m_ObjectId": "df231331c991426bafbf06d174991359",
+    "m_Id": 0,
+    "m_DisplayName": "Tangent",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Tangent",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PositionMaterialSlot",
+    "m_ObjectId": "ff809610946241b7b0fc05865dad1bd6",
+    "m_Id": 0,
+    "m_DisplayName": "Position",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Position",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+

--- a/Assets/Materials/Test/LitShader.shadergraph.meta
+++ b/Assets/Materials/Test/LitShader.shadergraph.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: a3cd58119c3b8524cbfa2dc30c580eb8
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 625f186215c104763be7675aa2d941aa, type: 3}

--- a/Assets/Materials/Test/White.mat
+++ b/Assets/Materials/Test/White.mat
@@ -21,7 +21,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: White
-  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Shader: {fileID: -6465566751694194690, guid: a3cd58119c3b8524cbfa2dc30c580eb8, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []
@@ -29,9 +29,8 @@ Material:
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap:
-    RenderType: Opaque
+  m_CustomRenderQueue: 1999
+  stringTagMap: {}
   disabledShaderPasses: []
   m_LockedProperties: 
   m_SavedProperties:
@@ -106,8 +105,8 @@ Material:
     - _Cutoff: 0.5
     - _DetailAlbedoMapScale: 1
     - _DetailNormalMapScale: 1
-    - _DstBlend: 0
-    - _DstBlendAlpha: 0
+    - _DstBlend: 10
+    - _DstBlendAlpha: 10
     - _EnvironmentReflections: 1
     - _GlossMapScale: 1
     - _Glossiness: 0.5
@@ -116,17 +115,18 @@ Material:
     - _Mode: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.02
-    - _QueueOffset: 0
+    - _QueueControl: 0
+    - _QueueOffset: -1
     - _ReceiveShadows: 1
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
-    - _Surface: 0
+    - _Surface: 1
     - _UVSec: 0
     - _WorkflowMode: 1
-    - _ZWrite: 1
+    - _ZWrite: 0
     m_Colors:
     - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
     - _Color: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Prefabs/Cannonball.prefab
+++ b/Assets/Prefabs/Cannonball.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 1551644109710311061}
   - component: {fileID: 7057518602764583131}
   - component: {fileID: 3478811497424437419}
-  - component: {fileID: 8332621496703665645}
+  - component: {fileID: 9010101338848325134}
   m_Layer: 0
   m_Name: Cannonball
   m_TagString: Untagged
@@ -84,24 +84,15 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!135 &8332621496703665645
-SphereCollider:
+--- !u!114 &9010101338848325134
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8370957803500371047}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 3
-  m_Radius: 0.5
-  m_Center: {x: 0, y: 0, z: 0}
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2833634a749f1684e9dacb003e64f460, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Cannonball.prefab
+++ b/Assets/Prefabs/Cannonball.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &9073670328388804027
+--- !u!1 &8370957803500371047
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,48 +8,47 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7434986082395353156}
-  - component: {fileID: 5036588224202421510}
-  - component: {fileID: 8900816372983775420}
-  - component: {fileID: 4046614497230479910}
-  - component: {fileID: 4055767820834326232}
+  - component: {fileID: 1551644109710311061}
+  - component: {fileID: 7057518602764583131}
+  - component: {fileID: 3478811497424437419}
+  - component: {fileID: 8332621496703665645}
   m_Layer: 0
-  m_Name: Pirate
+  m_Name: Cannonball
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7434986082395353156
+--- !u!4 &1551644109710311061
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9073670328388804027}
+  m_GameObject: {fileID: 8370957803500371047}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_LocalScale: {x: 0.7, y: 0.7, z: 0.7}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &5036588224202421510
+--- !u!33 &7057518602764583131
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9073670328388804027}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &8900816372983775420
+  m_GameObject: {fileID: 8370957803500371047}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &3478811497424437419
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9073670328388804027}
+  m_GameObject: {fileID: 8370957803500371047}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -63,7 +62,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 6ed8f40ef6c25e843b06dc3b098c5a12, type: 2}
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -85,13 +84,13 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &4046614497230479910
-BoxCollider:
+--- !u!135 &8332621496703665645
+SphereCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9073670328388804027}
+  m_GameObject: {fileID: 8370957803500371047}
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -104,18 +103,5 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
+  m_Radius: 0.5
   m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &4055767820834326232
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9073670328388804027}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 698f308d97e9a6540a11b3d44cbc6b11, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _cannonballPrefab: {fileID: 8370957803500371047, guid: 92576b53e1a6fff47aeea09bbdbc8fcd, type: 3}

--- a/Assets/Prefabs/Cannonball.prefab.meta
+++ b/Assets/Prefabs/Cannonball.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 92576b53e1a6fff47aeea09bbdbc8fcd
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Managers/Pirate Manager.prefab
+++ b/Assets/Prefabs/Managers/Pirate Manager.prefab
@@ -45,3 +45,4 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _piratePrefab: {fileID: 9073670328388804027, guid: 6f67b078318cef444943e4ee23b76276, type: 3}
+  _cannonballPrefab: {fileID: 8370957803500371047, guid: 92576b53e1a6fff47aeea09bbdbc8fcd, type: 3}

--- a/Assets/Prefabs/Managers/Pirate Manager.prefab
+++ b/Assets/Prefabs/Managers/Pirate Manager.prefab
@@ -1,0 +1,47 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1549051786115947554
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5754945084209723401}
+  - component: {fileID: 5300955414496215745}
+  m_Layer: 0
+  m_Name: Pirate Manager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5754945084209723401
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1549051786115947554}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5300955414496215745
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1549051786115947554}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 622fdf75f20d7df419be13942ca7185d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _piratePrefab: {fileID: 9073670328388804027, guid: 6f67b078318cef444943e4ee23b76276, type: 3}

--- a/Assets/Prefabs/Managers/Pirate Manager.prefab.meta
+++ b/Assets/Prefabs/Managers/Pirate Manager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5e0b1d9fd80a7c84cb593b5b7e94a37b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Managers/UI Manager.prefab
+++ b/Assets/Prefabs/Managers/UI Manager.prefab
@@ -3391,6 +3391,95 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &1796553297309418796
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4315667185250133763}
+  - component: {fileID: 7222092099482827022}
+  - component: {fileID: 1516212448203954797}
+  - component: {fileID: 1081661660524151083}
+  m_Layer: 5
+  m_Name: Fortress Info
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &4315667185250133763
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1796553297309418796}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8285800109765362508}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 240}
+  m_SizeDelta: {x: 260, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7222092099482827022
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1796553297309418796}
+  m_CullTransparentMesh: 1
+--- !u!114 &1516212448203954797
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1796553297309418796}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1081661660524151083
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1796553297309418796}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates: []
 --- !u!1 &1886696639442369060
 GameObject:
   m_ObjectHideFlags: 0
@@ -3904,6 +3993,7 @@ RectTransform:
   - {fileID: 4463058834330565838}
   - {fileID: 1238953837400598052}
   - {fileID: 8436544653154048960}
+  - {fileID: 4315667185250133763}
   - {fileID: 3648947727821457599}
   - {fileID: 5622926058077006120}
   - {fileID: 5601638983824595311}
@@ -3977,6 +4067,7 @@ MonoBehaviour:
   _happinessInfo: {fileID: 7851826970055027829}
   _timeToProduceInfo: {fileID: 3895095290754174326}
   _researchInfo: {fileID: 8099352710576030170}
+  _fortressInfo: {fileID: 1081661660524151083}
   _gaugeSlider: {fileID: 7842131346451617148}
   _gaugeText: {fileID: 2050868528061637184}
   _destroyButton: {fileID: 6672558496738698978}

--- a/Assets/Prefabs/Pirate.prefab
+++ b/Assets/Prefabs/Pirate.prefab
@@ -1,0 +1,120 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &9073670328388804027
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7434986082395353156}
+  - component: {fileID: 5036588224202421510}
+  - component: {fileID: 8900816372983775420}
+  - component: {fileID: 4046614497230479910}
+  - component: {fileID: 4055767820834326232}
+  m_Layer: 0
+  m_Name: Pirate
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7434986082395353156
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073670328388804027}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5036588224202421510
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073670328388804027}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8900816372983775420
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073670328388804027}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 6ed8f40ef6c25e843b06dc3b098c5a12, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &4046614497230479910
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073670328388804027}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &4055767820834326232
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073670328388804027}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 698f308d97e9a6540a11b3d44cbc6b11, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Pirate.prefab
+++ b/Assets/Prefabs/Pirate.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 7434986082395353156}
   - component: {fileID: 5036588224202421510}
   - component: {fileID: 8900816372983775420}
-  - component: {fileID: 4046614497230479910}
   - component: {fileID: 4055767820834326232}
   m_Layer: 0
   m_Name: Pirate
@@ -85,27 +84,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &4046614497230479910
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9073670328388804027}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &4055767820834326232
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Pirate.prefab
+++ b/Assets/Prefabs/Pirate.prefab
@@ -30,7 +30,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 0}
@@ -118,4 +118,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 698f308d97e9a6540a11b3d44cbc6b11, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _cannonballPrefab: {fileID: 8370957803500371047, guid: 92576b53e1a6fff47aeea09bbdbc8fcd, type: 3}

--- a/Assets/Prefabs/Pirate.prefab.meta
+++ b/Assets/Prefabs/Pirate.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6f67b078318cef444943e4ee23b76276
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -835,6 +835,10 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4892613928390725156, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4949818667534268066, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
       propertyPath: m_Name
       value: UI Manager
@@ -893,7 +897,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8470437041877012436, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0.00012207031
+      value: -0.00012207031
       objectReference: {fileID: 0}
     - target: {fileID: 9122111369357036391, guid: e96acf8e83f2d2344a7f3c788007329a, type: 3}
       propertyPath: m_Pivot.x

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -496,6 +496,63 @@ MonoBehaviour:
   m_DeselectOnBackgroundClick: 1
   m_PointerBehavior: 0
   m_CursorLockBehavior: 0
+--- !u!1001 &483149131915102760
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1549051786115947554, guid: 5e0b1d9fd80a7c84cb593b5b7e94a37b, type: 3}
+      propertyPath: m_Name
+      value: Pirate Manager
+      objectReference: {fileID: 0}
+    - target: {fileID: 5754945084209723401, guid: 5e0b1d9fd80a7c84cb593b5b7e94a37b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5754945084209723401, guid: 5e0b1d9fd80a7c84cb593b5b7e94a37b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5754945084209723401, guid: 5e0b1d9fd80a7c84cb593b5b7e94a37b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5754945084209723401, guid: 5e0b1d9fd80a7c84cb593b5b7e94a37b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5754945084209723401, guid: 5e0b1d9fd80a7c84cb593b5b7e94a37b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5754945084209723401, guid: 5e0b1d9fd80a7c84cb593b5b7e94a37b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5754945084209723401, guid: 5e0b1d9fd80a7c84cb593b5b7e94a37b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5754945084209723401, guid: 5e0b1d9fd80a7c84cb593b5b7e94a37b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5754945084209723401, guid: 5e0b1d9fd80a7c84cb593b5b7e94a37b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5754945084209723401, guid: 5e0b1d9fd80a7c84cb593b5b7e94a37b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5e0b1d9fd80a7c84cb593b5b7e94a37b, type: 3}
 --- !u!1001 &2400213661275808771
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -932,6 +989,10 @@ PrefabInstance:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 7748807012761875964, guid: 4135f9d9bf39f1b498980673a30275f7, type: 3}
+      propertyPath: _piratePrefab
+      value: 
+      objectReference: {fileID: 9073670328388804027, guid: 6f67b078318cef444943e4ee23b76276, type: 3}
+    - target: {fileID: 7748807012761875964, guid: 4135f9d9bf39f1b498980673a30275f7, type: 3}
       propertyPath: _dayNightAnimator
       value: 
       objectReference: {fileID: 705507997}
@@ -1111,3 +1172,4 @@ SceneRoots:
   - {fileID: 6510031156847264948}
   - {fileID: 2439005117313651965}
   - {fileID: 3193284147619751300}
+  - {fileID: 483149131915102760}

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -17,6 +17,9 @@ public class GameManager : SingletonBehaviour<GameManager>
     private const int MAX_RESEARCH_POINT = 100;
     private const float RESEARCH_COOLDOWN = 60.0f;
 
+    private const float PIRATE_SPAWN_PERIOD = 180.0f;
+    private const int MAX_PIRATE_SPAWN_COUNT = 2;
+
     [SerializeField] private MonoBehaviour[] _gameStates;
 
     [SerializeField] private Animator _dayNightAnimator;
@@ -24,6 +27,10 @@ public class GameManager : SingletonBehaviour<GameManager>
     private float _elapsedTime = 480.0f / DAY_SPEED;
     private float _riseCooldown = OCEAN_RISE_PERIOD;
     private float _researchCooldown = 0.0f;
+
+    private float _pirateSpawnCooldown = OCEAN_RISE_PERIOD;
+    private int _pirateSpawnProbabilityIndex = 0;
+    private int[] _pirateSpawnProbabilities = { 20, 60, 100 };
 
     private bool _hasEnded = false;
 
@@ -139,6 +146,7 @@ public class GameManager : SingletonBehaviour<GameManager>
 
         _dayNightAnimator.Play("Cycle", 0, (Mathf.RoundToInt(_elapsedTime * DAY_SPEED) % 1440) / 1440.0f);
 
+        // 연구 쿨타임 처리
         if (!_isResearchable)
         {
             _researchCooldown += Time.deltaTime;
@@ -146,6 +154,30 @@ public class GameManager : SingletonBehaviour<GameManager>
             if (_researchCooldown >= RESEARCH_COOLDOWN)
             {
                 _isResearchable = true;
+            }
+        }
+
+        // 해적 스폰 처리
+        _pirateSpawnCooldown -= Time.deltaTime;
+
+        if (_pirateSpawnCooldown < 0.0f)
+        {
+            _pirateSpawnCooldown += PIRATE_SPAWN_PERIOD;
+
+            if (Random.Range(1, 101) < _pirateSpawnProbabilities[_pirateSpawnProbabilityIndex])
+            {
+                int spawnCount = Random.Range(0, MAX_PIRATE_SPAWN_COUNT) + 1;
+
+                for (int i = 0; i < spawnCount; i++)
+                {
+                    PirateManager.Instance.SpawnPirate();
+                }
+
+                _pirateSpawnProbabilityIndex = 0;
+            }
+            else
+            {
+                _pirateSpawnProbabilityIndex = Mathf.Min(_pirateSpawnProbabilityIndex + 1, _pirateSpawnProbabilities.Length - 1);
             }
         }
     }

--- a/Assets/Scripts/Map/MapManager.cs
+++ b/Assets/Scripts/Map/MapManager.cs
@@ -39,6 +39,8 @@ public class MapManager : SingletonBehaviour<MapManager>
 
         _tiles = GetComponent<MapGenerator>().GenerateMap(128, 128, 6f);
         GetComponent<MapRenderer>().RenderMap();
+
+        PirateManager.Instance.UpdatePenalties();
     }
 
     private void Update()
@@ -85,6 +87,7 @@ public class MapManager : SingletonBehaviour<MapManager>
         }
 
         MapRenderer.Instance.RaiseOceanLevel(_oceanLevel, ++_oceanLevel);
+        PirateManager.Instance.UpdatePenalties();
     }
 
     public bool CheckCoordinateValidity(Vector2Int coordinate)

--- a/Assets/Scripts/Map/MapRenderer.cs
+++ b/Assets/Scripts/Map/MapRenderer.cs
@@ -511,39 +511,42 @@ public class MapRenderer : SingletonBehaviour<MapRenderer>
 
         while (elapsed < OCEAN_RISE_DURATION)
         {
-            elapsed += Time.deltaTime;
-
-            _oceanObject.transform.position = Vector3.Lerp(origianlPosition, newOceanPosition, elapsed / OCEAN_RISE_DURATION);
-
-            for (int i = 0; i < materials.Length; i++)
+            if (!GameManager.Instance.IsPaused && GameManager.Instance.GameState != GameState.Menu)
             {
-                materials[i].Lerp(materials[i], _sandMaterial, elapsed / OCEAN_RISE_DURATION);
-            }
+                elapsed += Time.deltaTime;
 
-            for (int i = 0; i < meshRenderers.Length; i++)
-            {
-                meshRenderers[i].materials = materials;
-            }
+                _oceanObject.transform.position = Vector3.Lerp(origianlPosition, newOceanPosition, elapsed / OCEAN_RISE_DURATION);
 
-            foreach (GameObject deck in _deckObjects.Values)
-            {
-                Vector3 position = deck.transform.position;
-                position.y = _oceanObject.transform.position.y;
-                deck.transform.position = position;
-            }
+                for (int i = 0; i < materials.Length; i++)
+                {
+                    materials[i].Lerp(materials[i], _sandMaterial, elapsed / OCEAN_RISE_DURATION);
+                }
 
-            foreach (KeyValuePair<Vector2Int, GameObject> highlight in _rangeObjects)
-            {
-                Vector3 position = highlight.Value.transform.position;
-                position.y = Mathf.Max(_oceanObject.transform.position.y, MapManager.Instance.Tiles[highlight.Key.x, highlight.Key.y].Height + 1.0f);
-                highlight.Value.transform.position = position;
-            }
+                for (int i = 0; i < meshRenderers.Length; i++)
+                {
+                    meshRenderers[i].materials = materials;
+                }
 
-            foreach (Vector2Int floatingStructure in _floatingStructures)
-            {
-                Vector3 position = _structureObjects[floatingStructure.x, floatingStructure.y].transform.position;
-                position.y = _oceanObject.transform.position.y;
-                _structureObjects[floatingStructure.x, floatingStructure.y].transform.position = position;
+                foreach (GameObject deck in _deckObjects.Values)
+                {
+                    Vector3 position = deck.transform.position;
+                    position.y = _oceanObject.transform.position.y;
+                    deck.transform.position = position;
+                }
+
+                foreach (KeyValuePair<Vector2Int, GameObject> highlight in _rangeObjects)
+                {
+                    Vector3 position = highlight.Value.transform.position;
+                    position.y = Mathf.Max(_oceanObject.transform.position.y, MapManager.Instance.Tiles[highlight.Key.x, highlight.Key.y].Height + 1.0f);
+                    highlight.Value.transform.position = position;
+                }
+
+                foreach (Vector2Int floatingStructure in _floatingStructures)
+                {
+                    Vector3 position = _structureObjects[floatingStructure.x, floatingStructure.y].transform.position;
+                    position.y = _oceanObject.transform.position.y;
+                    _structureObjects[floatingStructure.x, floatingStructure.y].transform.position = position;
+                }
             }
 
             yield return null;

--- a/Assets/Scripts/Pirate.meta
+++ b/Assets/Scripts/Pirate.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7c1f59044f9d0c94fbbe8cc88d1728ec
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Pirate/CannonballController.cs
+++ b/Assets/Scripts/Pirate/CannonballController.cs
@@ -1,0 +1,58 @@
+using UnityEngine;
+using UnityEngine.Events;
+
+/// <summary>
+/// 개별 대포알을 관리하는 클래스
+/// </summary>
+public class CannonballController : MonoBehaviour
+{
+    private const float CANNONBALL_DURATION_MODIFIER = 6.0f;
+    private const float CANNONBALL_GRAVITY = 16.0f;
+
+    private Vector3 _startPosition;
+    private Vector3 _endPosition;
+
+    private Vector3 _velocity;
+
+    private float _duration;
+    private float _elapsed;
+
+    private PirateController _targetPirate;
+
+    /// <summary>
+    /// 대포알의 상태를 초기화한다
+    /// </summary>
+    /// <param name="startPosition">시작 위치</param>
+    /// <param name="endPosition">종료 위치</param>
+    public void Initialize(Vector3 startPosition, Vector3 endPosition, PirateController targetPirate = null)
+    {
+        _startPosition = startPosition;
+        _endPosition = endPosition;
+
+        _duration = Vector3.Distance(_startPosition, _endPosition) / CANNONBALL_DURATION_MODIFIER;
+        _velocity = (_endPosition - _startPosition) / _duration + Vector3.up * CANNONBALL_GRAVITY * _duration / 2.0f;
+
+        _targetPirate = targetPirate;
+    }
+
+    private void Update()
+    {
+        if (!GameManager.Instance.IsPaused && GameManager.Instance.GameState != GameState.Menu)
+        {
+            _elapsed += Time.deltaTime;
+
+            transform.Translate(_velocity * Time.deltaTime);
+            _velocity -= Vector3.up * CANNONBALL_GRAVITY * Time.deltaTime;
+
+            if (_elapsed > _duration)
+            {
+                if (_targetPirate != null)
+                {
+                    _targetPirate.EndAttackPirate();
+                }
+
+                Destroy(gameObject);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Pirate/CannonballController.cs.meta
+++ b/Assets/Scripts/Pirate/CannonballController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2833634a749f1684e9dacb003e64f460
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Pirate/PirateController.cs
+++ b/Assets/Scripts/Pirate/PirateController.cs
@@ -48,12 +48,20 @@ public class PirateController : MonoBehaviour
         get => _attackingFortressCount > 0;
     }
 
+    /// <summary>
+    /// 해적의 현재 상태
+    /// </summary>
+    public PirateState CurrentState
+    {
+        get => _currentState;
+    }
+    private PirateState _currentState;
+
     private int _attackingFortressCount = 0;
 
     private int _currentHealth = MAX_HEALTH;
     private float _elapsed = 0.0f;
 
-    private PirateState _currentState;
     private Queue<Vector2Int> _path = new Queue<Vector2Int>();
 
     private void Update()

--- a/Assets/Scripts/Pirate/PirateController.cs
+++ b/Assets/Scripts/Pirate/PirateController.cs
@@ -1,0 +1,299 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public enum PirateState { Move, FirstAttack, SecondAttack, ThirdAttack, Despawn, Destroy }
+
+/// <summary>
+/// 개별 해적을 관리하는 클래스
+/// </summary>
+public class PirateController : MonoBehaviour
+{
+    private const float MOVE_SPEED = 2.0f;
+    private const float ROTATION_SPEED = 2.0f;
+
+    private const int COLLISION_FACTOR = 32;
+
+    private const float ATTACK_INTERVAL = 5.0f;
+    private const float MAX_HEALTH = 30.0f;
+
+    /// <summary>
+    /// 현재 위치 좌표
+    /// </summary>
+    public Vector2Int CurrentCoordinate
+    {
+        get => _currentCoordinate;
+    }
+    private Vector2Int _currentCoordinate;
+
+    /// <summary>
+    /// 공격 위치 좌표
+    /// </summary>
+    public Vector2Int TargetCoordinate
+    {
+        get => _targetCoordinate;
+    }
+    private Vector2Int _targetCoordinate;
+
+    private float _currentHealth = MAX_HEALTH;
+    private float _elapsed = 0.0f;
+
+    private PirateState _currentState;
+    private Queue<Vector2Int> _path = new Queue<Vector2Int>();
+
+    private MeshRenderer _meshRenderer;
+
+    private void Update()
+    {
+        if (GameManager.Instance.IsPaused || GameManager.Instance.GameState == GameState.Menu)
+        {
+            return;
+        }
+
+        // 체력이 0이 된 경우 파괴
+        if (_currentState < PirateState.Despawn && _currentHealth <= 0.0f)
+        {
+            _currentState = PirateState.Destroy;
+
+            StartCoroutine(CoDestroyPirate());
+        }
+
+        // 현재 상태에 따라 로직 수행
+        switch (_currentState)
+        {
+            case PirateState.Move:
+                {
+                    // 이동할 경로가 남은 경우
+                    if (_path.Count > 0)
+                    {
+                        float distanceToMove = Time.deltaTime * MOVE_SPEED;
+
+                        while (distanceToMove > 0.0f && _path.Count > 0)
+                        {
+                            Vector3 targetPosition = HexaUtility.GetWorldCoordinate(_path.Peek());
+                            targetPosition.y = MapRenderer.Instance.OceanHeight;
+                            Vector3 forward = targetPosition - transform.position;
+
+                            if (forward != Vector3.zero)
+                            {
+                                transform.rotation = Quaternion.Lerp(transform.rotation, Quaternion.LookRotation(forward), Time.deltaTime * ROTATION_SPEED);
+                            }
+
+                            float moveDelta = Vector3.Distance(transform.position, targetPosition);
+
+                            if (distanceToMove >= moveDelta)
+                            {
+                                distanceToMove -= moveDelta;
+                                transform.position = targetPosition;
+
+                                _currentCoordinate = _path.Dequeue();
+
+                                if (_path.Count > 0 && !PirateManager.Instance.CheckFreeCoordinate(_path.Peek(), this))
+                                {
+                                    GetPath();
+                                    break;
+                                }
+                            }
+                            else
+                            {
+                                transform.position = Vector3.MoveTowards(transform.position, targetPosition, distanceToMove);
+                                break;
+                            }
+                        }
+                    }
+                    // 목표에 도달한 경우
+                    else
+                    {
+                        _currentState++;
+                        _elapsed = 0.0f;
+                    }
+                    break;
+                }
+            case PirateState.FirstAttack:
+            case PirateState.SecondAttack:
+            case PirateState.ThirdAttack:
+                {
+                    _elapsed += Time.deltaTime;
+
+                    if (_elapsed > ATTACK_INTERVAL)
+                    {
+                        _elapsed -= ATTACK_INTERVAL;
+                        _currentState++;
+
+                        StartCoroutine(CoAttack());
+                    }
+
+                    // 공격을 마친 경우
+                    if (_currentState == PirateState.Despawn)
+                    {
+                        GameManager.Instance.ChangeResearchPoint(-10);
+
+                        StartCoroutine(CoDespawnPirate());
+                    }
+
+                    break;
+                }
+        }
+    }
+
+    /// <summary>
+    /// 해적의 상태를 초기화한다
+    /// </summary>
+    /// <param name="startCoordinate">시작 위치 좌표</param>
+    /// <param name="targetCoordinate">공격 위치 좌표</param>
+    public void Initialize(Vector2Int startCoordinate, Vector2Int targetCoordinate, bool playSpawnAnimation = true)
+    {
+        _currentCoordinate = startCoordinate;
+        _targetCoordinate = targetCoordinate;
+
+        _currentState = PirateState.Move;
+
+        _meshRenderer = GetComponent<MeshRenderer>();
+
+        GetPath();
+
+        if (_path.Count > 0)
+        {
+            Vector3 currentPosition = HexaUtility.GetWorldCoordinate(_currentCoordinate);
+            currentPosition.y = MapRenderer.Instance.OceanHeight;
+            transform.position = currentPosition;
+
+            Vector3 targetPosition = HexaUtility.GetWorldCoordinate(_path.Peek());
+            targetPosition.y = MapRenderer.Instance.OceanHeight;
+            Vector3 forward = targetPosition - transform.position;
+
+            if (forward != Vector3.zero)
+            {
+                transform.rotation = Quaternion.LookRotation(forward);
+            }
+        }
+
+        if (playSpawnAnimation)
+        {
+            StartCoroutine(CoSpawnPirate());
+        }
+    }
+
+    /// <summary>
+    /// 현재 좌표에서 목표 좌표로의 경로를 계산한다.
+    /// </summary>
+    private void GetPath()
+    {
+        if (_currentCoordinate == _targetCoordinate)
+        {
+            _path.Clear();
+            return;
+        }
+
+        PriorityQueue<Vector2Int, int> queue = new PriorityQueue<Vector2Int, int>();
+        Dictionary<Vector2Int, Vector2Int> previous = new Dictionary<Vector2Int, Vector2Int>();
+        Dictionary<Vector2Int, int> distance = new Dictionary<Vector2Int, int>();
+
+        Stack<Vector2Int> pathStack = new Stack<Vector2Int>();
+
+        queue.Enqueue(_currentCoordinate, 0);
+        previous[_currentCoordinate] = new Vector2Int(-1, -1);
+        distance[_currentCoordinate] = 0;
+
+        while (queue.Count > 0)
+        {
+            Vector2Int current = queue.Dequeue();
+
+            if (current == _targetCoordinate)
+            {
+                break;
+            }
+
+            for (int i = 0; i < 6; i++)
+            {
+                Vector2Int next = HexaUtility.GetNeighbor(current, (TileNeighbor)i);
+
+                if (MapManager.Instance.CheckCoordinateValidity(next) && MapManager.Instance.Tiles[next.x, next.y].IsUnderWater) {
+                    int alternative = distance[current] + 1 + PirateManager.Instance.Penalties[next.x, next.y];
+
+                    if (!PirateManager.Instance.CheckFreeCoordinate(next, this))
+                    {
+                        alternative += COLLISION_FACTOR;
+                    }
+
+                    if (!distance.ContainsKey(next) || distance[next] > alternative)
+                    {
+                        previous[next] = current;
+                        distance[next] = alternative;
+
+                        queue.Enqueue(next, alternative + HexaUtility.GetDistance(next, _targetCoordinate));
+                    }
+                }
+            }
+        }
+
+        Vector2Int pathTrack = _targetCoordinate;
+        pathStack.Push(pathTrack);
+
+        while (previous[pathTrack].x != -1) {
+            pathStack.Push(previous[pathTrack]);
+
+            pathTrack = previous[pathTrack];
+        }
+
+        pathStack.Pop();
+        _path.Clear();
+
+        while (pathStack.Count > 0)
+        {
+            _path.Enqueue(pathStack.Pop());
+        }
+    }
+
+    /// <summary>
+    /// 스폰 애니메이션을 재생한다.
+    /// </summary>
+    private IEnumerator CoSpawnPirate()
+    {
+        float elapsed = 0.0f;
+
+        Color startColor = _meshRenderer.material.color;
+        Color endColor = startColor;
+        startColor.a = 0.0f;
+
+        while (true)
+        {
+            if (!GameManager.Instance.IsPaused && GameManager.Instance.GameState != GameState.Menu)
+            {
+                elapsed += Time.deltaTime;
+                _meshRenderer.material.color = Color.Lerp(startColor, endColor, elapsed / 3.0f);
+
+                if (elapsed > 3.0f)
+                {
+                    break;
+                }
+            }
+
+            yield return null;
+        }
+    }
+
+    /// <summary>
+    /// 공격 애니메이션을 재생한다.
+    /// </summary>
+    private IEnumerator CoAttack()
+    {
+        yield return null;
+    }
+
+    /// <summary>
+    /// 디스폰 애니메이션을 재생한다.
+    /// </summary>
+    private IEnumerator CoDespawnPirate()
+    {
+        yield return null;
+    }
+
+    /// <summary>
+    /// 파괴 애니메이션을 재생한다.
+    /// </summary>
+    private IEnumerator CoDestroyPirate()
+    {
+        yield return null;
+    }
+}

--- a/Assets/Scripts/Pirate/PirateController.cs
+++ b/Assets/Scripts/Pirate/PirateController.cs
@@ -15,17 +15,12 @@ public class PirateController : MonoBehaviour
     private const int COLLISION_FACTOR = 32;
 
     private const float ATTACK_INTERVAL = 2.0f;
-    private const float MAX_HEALTH = 30.0f;
+    private const int MAX_HEALTH = 3;
 
     private const float SPAWN_ANIMATION_DURATION = 3.0f;
     private const float DESPAWN_ANIMATION_DELAY = 3.0f;
     private const float DESPAWN_ANIMATION_DURATION = 3.0f;
     private const float DESTROY_ANIMATION_DURATION = 3.0f;
-
-    private const float CANNONBALL_DURATION = 1.5f;
-    private const float CANNONBALL_GRAVITY = 16.0f;
-
-    [SerializeField] GameObject _cannonballPrefab;
 
     /// <summary>
     /// 현재 위치 좌표
@@ -45,13 +40,21 @@ public class PirateController : MonoBehaviour
     }
     private Vector2Int _targetCoordinate;
 
-    private float _currentHealth = MAX_HEALTH;
+    /// <summary>
+    /// 해적이 공격받고 있는지 여부
+    /// </summary>
+    public bool IsUnderAttack
+    {
+        get => _attackingFortressCount > 0;
+    }
+
+    private int _attackingFortressCount = 0;
+
+    private int _currentHealth = MAX_HEALTH;
     private float _elapsed = 0.0f;
 
     private PirateState _currentState;
     private Queue<Vector2Int> _path = new Queue<Vector2Int>();
-
-    private MeshRenderer _meshRenderer;
 
     private void Update()
     {
@@ -61,9 +64,10 @@ public class PirateController : MonoBehaviour
         }
 
         // 체력이 0이 된 경우 파괴
-        if (_currentState < PirateState.Despawn && _currentHealth <= 0.0f)
+        if (_currentState < PirateState.Despawn && _currentHealth <= 0)
         {
             _currentState = PirateState.Destroy;
+            _path.Clear();
 
             StartCoroutine(CoDestroyPirate());
         }
@@ -130,7 +134,21 @@ public class PirateController : MonoBehaviour
                         _elapsed -= ATTACK_INTERVAL;
                         _currentState++;
 
-                        StartCoroutine(CoAttack());
+                        // 공격 위치 탐색
+                        Vector3 startPosition = transform.position;
+                        Vector3 endPosition = new Vector3();
+
+                        foreach (Vector2Int neighbor in HexaUtility.GetNeighbors(_currentCoordinate, 6))
+                        {
+                            if (MapManager.Instance.CheckCoordinateValidity(neighbor) && !MapManager.Instance.Tiles[neighbor.x, neighbor.y].IsUnderWater)
+                            {
+                                endPosition = HexaUtility.GetWorldCoordinate(neighbor);
+                                endPosition.y = MapManager.Instance.Tiles[neighbor.x, neighbor.y].Height;
+                                break;
+                            }
+                        }
+
+                        PirateManager.Instance.SpawnCannonball(startPosition, endPosition);
                     }
 
                     // 공격을 마친 경우
@@ -158,8 +176,6 @@ public class PirateController : MonoBehaviour
 
         _currentState = PirateState.Move;
 
-        _meshRenderer = GetComponent<MeshRenderer>();
-
         GetPath();
 
         if (_path.Count > 0)
@@ -182,6 +198,41 @@ public class PirateController : MonoBehaviour
         {
             StartCoroutine(CoSpawnPirate());
         }
+    }
+
+    /// <summary>
+    /// 경로 상에서 나중에 접근할 예정인 타일을 반환한다.
+    /// </summary>
+    /// <param name="futureIndex">경로 인덱스 (0: 바로 다음 타일)</param>
+    public Vector2Int GetFutureCoordinate(int futureIndex)
+    {
+        Vector2Int[] futureCoordinates = _path.ToArray();
+
+        if (_path.Count == 0)
+        {
+            return _currentCoordinate;
+        }
+        else
+        {
+            return futureCoordinates[Mathf.Min(futureIndex, futureCoordinates.Length - 1)];
+        }
+    }
+
+    /// <summary>
+    /// 현재 해적을 상대로 공격을 시작한다.
+    /// </summary>
+    public void StartAttackPirate()
+    {
+        _attackingFortressCount++;
+    }
+
+    /// <summary>
+    /// 현재 해적을 상대로 공격을 중단한다.
+    /// </summary>
+    public void EndAttackPirate()
+    {
+        _attackingFortressCount--;
+        _currentHealth--;
     }
 
     /// <summary>
@@ -283,53 +334,6 @@ public class PirateController : MonoBehaviour
     }
 
     /// <summary>
-    /// 공격 애니메이션을 재생한다.
-    /// </summary>
-    private IEnumerator CoAttack()
-    {
-        Vector3 startPosition = transform.position;
-        Vector3 endPosition = new Vector3();
-
-        // 공격 위치 탐색
-        foreach (Vector2Int neighbor in HexaUtility.GetNeighbors(_currentCoordinate, 6))
-        {
-            if (MapManager.Instance.CheckCoordinateValidity(neighbor) && !MapManager.Instance.Tiles[neighbor.x, neighbor.y].IsUnderWater)
-            {
-                endPosition = HexaUtility.GetWorldCoordinate(neighbor);
-                endPosition.y = MapManager.Instance.Tiles[neighbor.x, neighbor.y].Height;
-                break;
-            }
-        }
-
-        GameObject cannonball = Instantiate(_cannonballPrefab);
-        cannonball.transform.position = transform.position;
-
-        // 최초 속도 계산: v0 = (x1 - x0) / t + a * t / 2;
-        Vector3 velocity = (endPosition - startPosition) / CANNONBALL_DURATION + Vector3.up * CANNONBALL_GRAVITY * CANNONBALL_DURATION / 2.0f;
-        float elapsed = 0.0f;
-
-        while (true)
-        {
-            if (!GameManager.Instance.IsPaused && GameManager.Instance.GameState != GameState.Menu)
-            {
-                elapsed += Time.deltaTime;
-
-                cannonball.transform.Translate(velocity * Time.deltaTime);
-                velocity -= Vector3.up * CANNONBALL_GRAVITY * Time.deltaTime;
-
-                if (elapsed > CANNONBALL_DURATION)
-                {
-                    break;
-                }
-            }
-
-            yield return null;
-        }
-
-        Destroy(cannonball);
-    }
-
-    /// <summary>
     /// 디스폰 애니메이션을 재생한다.
     /// </summary>
     private IEnumerator CoDespawnPirate()
@@ -400,5 +404,7 @@ public class PirateController : MonoBehaviour
         }
 
         // End Animation
+
+        PirateManager.Instance.DespawnPirate(this);
     }
 }

--- a/Assets/Scripts/Pirate/PirateController.cs
+++ b/Assets/Scripts/Pirate/PirateController.cs
@@ -63,6 +63,11 @@ public class PirateController : MonoBehaviour
             return;
         }
 
+        // 해수면의 위치에 따라 해적의 위치도 변경
+        Vector3 newPosition = transform.position;
+        newPosition.y = MapRenderer.Instance.OceanHeight;
+        transform.position = newPosition;
+
         // 체력이 0이 된 경우 파괴
         if (_currentState < PirateState.Despawn && _currentHealth <= 0)
         {

--- a/Assets/Scripts/Pirate/PirateController.cs
+++ b/Assets/Scripts/Pirate/PirateController.cs
@@ -14,8 +14,18 @@ public class PirateController : MonoBehaviour
 
     private const int COLLISION_FACTOR = 32;
 
-    private const float ATTACK_INTERVAL = 5.0f;
+    private const float ATTACK_INTERVAL = 2.0f;
     private const float MAX_HEALTH = 30.0f;
+
+    private const float SPAWN_ANIMATION_DURATION = 3.0f;
+    private const float DESPAWN_ANIMATION_DELAY = 3.0f;
+    private const float DESPAWN_ANIMATION_DURATION = 3.0f;
+    private const float DESTROY_ANIMATION_DURATION = 3.0f;
+
+    private const float CANNONBALL_DURATION = 1.5f;
+    private const float CANNONBALL_GRAVITY = 16.0f;
+
+    [SerializeField] GameObject _cannonballPrefab;
 
     /// <summary>
     /// 현재 위치 좌표
@@ -252,18 +262,15 @@ public class PirateController : MonoBehaviour
     {
         float elapsed = 0.0f;
 
-        Color startColor = _meshRenderer.material.color;
-        Color endColor = startColor;
-        startColor.a = 0.0f;
+        // Start Animation
 
         while (true)
         {
             if (!GameManager.Instance.IsPaused && GameManager.Instance.GameState != GameState.Menu)
             {
                 elapsed += Time.deltaTime;
-                _meshRenderer.material.color = Color.Lerp(startColor, endColor, elapsed / 3.0f);
 
-                if (elapsed > 3.0f)
+                if (elapsed > SPAWN_ANIMATION_DURATION)
                 {
                     break;
                 }
@@ -271,6 +278,8 @@ public class PirateController : MonoBehaviour
 
             yield return null;
         }
+
+        // End Animation
     }
 
     /// <summary>
@@ -278,7 +287,46 @@ public class PirateController : MonoBehaviour
     /// </summary>
     private IEnumerator CoAttack()
     {
-        yield return null;
+        Vector3 startPosition = transform.position;
+        Vector3 endPosition = new Vector3();
+
+        // 공격 위치 탐색
+        foreach (Vector2Int neighbor in HexaUtility.GetNeighbors(_currentCoordinate, 6))
+        {
+            if (MapManager.Instance.CheckCoordinateValidity(neighbor) && !MapManager.Instance.Tiles[neighbor.x, neighbor.y].IsUnderWater)
+            {
+                endPosition = HexaUtility.GetWorldCoordinate(neighbor);
+                endPosition.y = MapManager.Instance.Tiles[neighbor.x, neighbor.y].Height;
+                break;
+            }
+        }
+
+        GameObject cannonball = Instantiate(_cannonballPrefab);
+        cannonball.transform.position = transform.position;
+
+        // 최초 속도 계산: v0 = (x1 - x0) / t + a * t / 2;
+        Vector3 velocity = (endPosition - startPosition) / CANNONBALL_DURATION + Vector3.up * CANNONBALL_GRAVITY * CANNONBALL_DURATION / 2.0f;
+        float elapsed = 0.0f;
+
+        while (true)
+        {
+            if (!GameManager.Instance.IsPaused && GameManager.Instance.GameState != GameState.Menu)
+            {
+                elapsed += Time.deltaTime;
+
+                cannonball.transform.Translate(velocity * Time.deltaTime);
+                velocity -= Vector3.up * CANNONBALL_GRAVITY * Time.deltaTime;
+
+                if (elapsed > CANNONBALL_DURATION)
+                {
+                    break;
+                }
+            }
+
+            yield return null;
+        }
+
+        Destroy(cannonball);
     }
 
     /// <summary>
@@ -286,7 +334,45 @@ public class PirateController : MonoBehaviour
     /// </summary>
     private IEnumerator CoDespawnPirate()
     {
-        yield return null;
+        float elapsed = 0.0f;
+
+        while (true)
+        {
+            if (!GameManager.Instance.IsPaused && GameManager.Instance.GameState != GameState.Menu)
+            {
+                elapsed += Time.deltaTime;
+
+                if (elapsed > DESPAWN_ANIMATION_DELAY)
+                {
+                    break;
+                }
+            }
+
+            yield return null;
+        }
+
+        elapsed -= 3.0f;
+
+        // Start Animation
+
+        while (true)
+        {
+            if (!GameManager.Instance.IsPaused && GameManager.Instance.GameState != GameState.Menu)
+            {
+                elapsed += Time.deltaTime;
+
+                if (elapsed > DESPAWN_ANIMATION_DURATION)
+                {
+                    break;
+                }
+            }
+
+            yield return null;
+        }
+
+        // End Animation
+
+        PirateManager.Instance.DespawnPirate(this);
     }
 
     /// <summary>
@@ -294,6 +380,25 @@ public class PirateController : MonoBehaviour
     /// </summary>
     private IEnumerator CoDestroyPirate()
     {
-        yield return null;
+        float elapsed = 0.0f;
+
+        // Start Animation
+
+        while (true)
+        {
+            if (!GameManager.Instance.IsPaused && GameManager.Instance.GameState != GameState.Menu)
+            {
+                elapsed += Time.deltaTime;
+
+                if (elapsed > DESTROY_ANIMATION_DURATION)
+                {
+                    break;
+                }
+            }
+
+            yield return null;
+        }
+
+        // End Animation
     }
 }

--- a/Assets/Scripts/Pirate/PirateController.cs
+++ b/Assets/Scripts/Pirate/PirateController.cs
@@ -136,17 +136,47 @@ public class PirateController : MonoBehaviour
 
                         // 공격 위치 탐색
                         Vector3 startPosition = transform.position;
+                        Vector2Int endCoordinate = new Vector2Int();
                         Vector3 endPosition = new Vector3();
 
-                        foreach (Vector2Int neighbor in HexaUtility.GetNeighbors(_currentCoordinate, 6))
+                        List<Vector2Int> neighborsWithStructure = new List<Vector2Int>();
+                        List<Vector2Int> neighborsWithoutStructure = new List<Vector2Int>();
+                        List<Vector2Int> neighborsUnderWater = new List<Vector2Int>();
+
+                        foreach (Vector2Int neighbor in HexaUtility.GetNeighbors(_currentCoordinate, 4))
                         {
-                            if (MapManager.Instance.CheckCoordinateValidity(neighbor) && !MapManager.Instance.Tiles[neighbor.x, neighbor.y].IsUnderWater)
+                            if (MapManager.Instance.CheckCoordinateValidity(neighbor))
                             {
-                                endPosition = HexaUtility.GetWorldCoordinate(neighbor);
-                                endPosition.y = MapManager.Instance.Tiles[neighbor.x, neighbor.y].Height;
-                                break;
+                                if (MapManager.Instance.Tiles[neighbor.x, neighbor.y].Structure != null)
+                                {
+                                    neighborsWithStructure.Add(neighbor);
+                                }
+                                else if (!MapManager.Instance.Tiles[neighbor.x, neighbor.y].IsUnderWater)
+                                {
+                                    neighborsWithoutStructure.Add(neighbor);
+                                }
+                                else
+                                {
+                                    neighborsUnderWater.Add(neighbor);
+                                }
                             }
                         }
+
+                        if (neighborsWithStructure.Count > 0)
+                        {
+                            endCoordinate = neighborsWithStructure[Random.Range(0, neighborsWithStructure.Count)];
+                        }
+                        else if (neighborsWithoutStructure.Count > 0)
+                        {
+                            endCoordinate = neighborsWithoutStructure[Random.Range(0, neighborsWithoutStructure.Count)];
+                        }
+                        else
+                        {
+                            endCoordinate = neighborsUnderWater[Random.Range(0, neighborsUnderWater.Count)];
+                        }
+
+                        endPosition = HexaUtility.GetWorldCoordinate(endCoordinate);
+                        endPosition.y = Mathf.Max(MapManager.Instance.Tiles[endCoordinate.x, endCoordinate.y].Height, MapRenderer.Instance.OceanHeight);
 
                         PirateManager.Instance.SpawnCannonball(startPosition, endPosition);
                     }

--- a/Assets/Scripts/Pirate/PirateController.cs.meta
+++ b/Assets/Scripts/Pirate/PirateController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 698f308d97e9a6540a11b3d44cbc6b11
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Pirate/PirateManager.cs
+++ b/Assets/Scripts/Pirate/PirateManager.cs
@@ -1,0 +1,211 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// 게임 내 모든 해적을 관리하는 클래스
+/// </summary>
+public class PirateManager : SingletonBehaviour<PirateManager>
+{
+    private const int PENALTY_RANGE = 3;    // 육지와 가까운 타일을 인식할 범위
+
+    [SerializeField] private GameObject _piratePrefab;
+
+    /// <summary>
+    /// 현재 게임에 존재하는 모든 해적
+    /// </summary>
+    public IReadOnlyList<PirateController> Pirates
+    {
+        get => _pirates;
+    }
+    private List<PirateController> _pirates = new List<PirateController>();
+
+    /// <summary>
+    /// 육지와 가까운 타일에 부여할 이동 비용 페널티
+    /// </summary>
+    public int[,] Penalties
+    {
+        get => _penalties;
+    }
+    private int[,] _penalties;
+
+    private void Update()
+    {
+        //QualitySettings.vSyncCount = 0;
+        //Application.targetFrameRate = 30;
+
+        // TEST
+        if (Input.GetKeyDown(KeyCode.P))
+        {
+            UpdatePenalties();
+            SpawnPirate();
+        }
+    }
+
+    /// <summary>
+    /// 해적을 생성한다.
+    /// </summary>
+    public void SpawnPirate()
+    {
+        // 시작 위치 지정
+        Vector2Int spawnPosition = Vector2Int.zero;
+
+        do
+        {
+            int direction = Random.Range(0, 4);
+
+            switch (direction)
+            {
+                case 0:
+                    spawnPosition.x = 0;
+                    spawnPosition.y = Random.Range(0, MapManager.Instance.Tiles.GetLength(1));
+                    break;
+                case 1:
+                    spawnPosition.x = MapManager.Instance.Tiles.GetLength(0);
+                    spawnPosition.y = Random.Range(0, MapManager.Instance.Tiles.GetLength(1));
+                    break;
+                case 2:
+                    spawnPosition.x = Random.Range(0, MapManager.Instance.Tiles.GetLength(0));
+                    spawnPosition.y = 0;
+                    break;
+                case 3:
+                    spawnPosition.x = Random.Range(0, MapManager.Instance.Tiles.GetLength(0));
+                    spawnPosition.y = MapManager.Instance.Tiles.GetLength(1);
+                    break;
+            }
+        }
+        while (!CheckFreeCoordinate(spawnPosition));
+
+        // 해적 오브젝트 생성
+        GameObject pirateObject = Instantiate(_piratePrefab);
+
+        PirateController pirateController = pirateObject.GetComponent<PirateController>();
+        _pirates.Add(pirateController);
+
+        // 해적 목표 지정
+        Vector2Int[] neighbors = HexaUtility.GetNeighbors(new Vector2Int(MapManager.Instance.Tiles.GetLength(0) / 2, MapManager.Instance.Tiles.GetLength(1) / 2), 30);
+
+        int n = neighbors.Length;
+
+        while (n > 1)
+        {
+            n--;
+
+            int k = Random.Range(0, n + 1);
+            (neighbors[k], neighbors[n]) = (neighbors[n], neighbors[k]);
+        }
+
+        foreach (Vector2Int neighbor in neighbors)
+        {
+            if (MapManager.Instance.Tiles[neighbor.x, neighbor.y].IsUnderWater && CheckOceanAccessibility(neighbor))
+            {
+                pirateController.Initialize(spawnPosition, neighbor);
+                break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// 해적을 제거한다.
+    /// </summary>
+    /// <param name="pirateController">제거할 해적</param>
+    public void DespawnPirate(PirateController pirateController)
+    {
+        _pirates.Remove(pirateController);
+        Destroy(pirateController.gameObject);
+    }
+
+    /// <summary>
+    /// 해당 위치에 다른 해적이 없는지 확인한다.
+    /// </summary>
+    /// <param name="coordinate">위치</param>
+    /// /// <param name="exception">제외할 해적</param>
+    public bool CheckFreeCoordinate(Vector2Int coordinate, PirateController exception = null)
+    {
+        foreach (PirateController pirateController in _pirates)
+        {
+            if (pirateController == exception)
+            {
+                continue;
+            }
+
+            if (pirateController.CurrentCoordinate == coordinate)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// 해당 위치에서 바다로 나갈 수 있는지 확인한다.
+    /// </summary>
+    /// <param name="coordinate">위치</param>
+    private bool CheckOceanAccessibility(Vector2Int coordinate)
+    {
+        int w = MapManager.Instance.Tiles.GetLength(0);
+        int h = MapManager.Instance.Tiles.GetLength(1);
+
+        bool[,] visited = new bool[w, h];
+
+        Queue<Vector2Int> queue = new Queue<Vector2Int>();
+        queue.Enqueue(coordinate);
+
+        while (queue.Count > 0)
+        {
+            Vector2Int current = queue.Dequeue();
+
+            if (current.x == 0 || current.x == MapManager.Instance.Tiles.GetLength(0) - 1 ||
+                current.y == 0 || current.y == MapManager.Instance.Tiles.GetLength(1) - 1)
+            {
+                return true;
+            }
+
+            if (visited[current.x, current.y])
+            {
+                continue;
+            }
+
+            visited[current.x, current.y] = true;
+
+            for (int i = 0; i < 6; i++)
+            {
+                Vector2Int neighbor = HexaUtility.GetNeighbor(current, (TileNeighbor)i);
+
+                if (MapManager.Instance.CheckCoordinateValidity(neighbor) && MapManager.Instance.Tiles[neighbor.x, neighbor.y].IsUnderWater && !visited[neighbor.x, neighbor.y])
+                {
+                    queue.Enqueue(neighbor);
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// 이동 비용 페널티 정보를 갱신한다.
+    /// </summary>
+    private void UpdatePenalties()
+    {
+        int w = MapManager.Instance.Tiles.GetLength(0);
+        int h = MapManager.Instance.Tiles.GetLength(1);
+
+        _penalties = new int[w, h];
+
+        for (int i = 0; i < w; i++)
+        {
+            for (int j = 0; j < h; j++)
+            {
+                if (!MapManager.Instance.Tiles[i, j].IsUnderWater)
+                {
+                    Vector2Int[] neighbors = HexaUtility.GetNeighbors(new Vector2Int(i, j), PENALTY_RANGE);
+
+                    foreach (Vector2Int neighbor in neighbors)
+                    {
+                        _penalties[neighbor.x, neighbor.y]++;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Pirate/PirateManager.cs
+++ b/Assets/Scripts/Pirate/PirateManager.cs
@@ -9,6 +9,7 @@ public class PirateManager : SingletonBehaviour<PirateManager>
     private const int PENALTY_RANGE = 3;    // 육지와 가까운 타일을 인식할 범위
 
     [SerializeField] private GameObject _piratePrefab;
+    [SerializeField] private GameObject _cannonballPrefab;
 
     /// <summary>
     /// 현재 게임에 존재하는 모든 해적
@@ -36,7 +37,6 @@ public class PirateManager : SingletonBehaviour<PirateManager>
         // TEST
         if (Input.GetKeyDown(KeyCode.P))
         {
-            UpdatePenalties();
             SpawnPirate();
         }
     }
@@ -185,7 +185,7 @@ public class PirateManager : SingletonBehaviour<PirateManager>
     /// <summary>
     /// 이동 비용 페널티 정보를 갱신한다.
     /// </summary>
-    private void UpdatePenalties()
+    public void UpdatePenalties()
     {
         int w = MapManager.Instance.Tiles.GetLength(0);
         int h = MapManager.Instance.Tiles.GetLength(1);
@@ -207,5 +207,19 @@ public class PirateManager : SingletonBehaviour<PirateManager>
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// 대포알을 스폰한다.
+    /// </summary>
+    /// <param name="startPosition">시작 위치</param>
+    /// <param name="endPosition">종료 위치</param>
+    /// <param name="duration">지속 시간</param>
+    public void SpawnCannonball(Vector3 startPosition, Vector3 endPosition, PirateController targetPirate = null)
+    {
+        GameObject cannonball = Instantiate(_cannonballPrefab);
+        cannonball.transform.position = startPosition;
+
+        cannonball.GetComponent<CannonballController>().Initialize(startPosition, endPosition, targetPirate);
     }
 }

--- a/Assets/Scripts/Pirate/PirateManager.cs
+++ b/Assets/Scripts/Pirate/PirateManager.cs
@@ -12,6 +12,11 @@ public class PirateManager : SingletonBehaviour<PirateManager>
     [SerializeField] private GameObject _cannonballPrefab;
 
     /// <summary>
+    /// 현재 해적이 공격하고 있는 타일
+    /// </summary>
+    private HashSet<Vector2Int> _targets = new HashSet<Vector2Int>();
+
+    /// <summary>
     /// 현재 게임에 존재하는 모든 해적
     /// </summary>
     public IReadOnlyList<PirateController> Pirates
@@ -44,10 +49,37 @@ public class PirateManager : SingletonBehaviour<PirateManager>
     /// <summary>
     /// 해적을 생성한다.
     /// </summary>
-    public void SpawnPirate()
+    public bool SpawnPirate()
     {
+        // 해적 목표 지정
+        List<Vector2Int> targetCandidates = new List<Vector2Int>();
+
+        foreach (Tile tile in MapManager.Instance.Tiles)
+        {
+            if (tile.Structure != null)
+            {
+                Vector2Int[] neighbors = HexaUtility.GetNeighbors(tile.Coordinate, 3);
+
+                foreach (Vector2Int neighbor in neighbors)
+                {
+                    if (!_targets.Contains(neighbor) && MapManager.Instance.CheckCoordinateValidity(neighbor) && MapManager.Instance.Tiles[neighbor.x, neighbor.y].IsUnderWater && CheckOceanAccessibility(neighbor))
+                    {
+                        targetCandidates.Add(neighbor);
+                    }
+                }
+            }
+        }
+
+        if (targetCandidates.Count == 0)
+        {
+            Debug.LogError("Couldn't find an attack target!");
+            return false;
+        }
+
+        Vector2Int targetCoordinate = targetCandidates[Random.Range(0, targetCandidates.Count)];
+
         // 시작 위치 지정
-        Vector2Int spawnPosition = Vector2Int.zero;
+        Vector2Int startCoordinate = Vector2Int.zero;
 
         do
         {
@@ -56,24 +88,24 @@ public class PirateManager : SingletonBehaviour<PirateManager>
             switch (direction)
             {
                 case 0:
-                    spawnPosition.x = 0;
-                    spawnPosition.y = Random.Range(0, MapManager.Instance.Tiles.GetLength(1));
+                    startCoordinate.x = 0;
+                    startCoordinate.y = Random.Range(0, MapManager.Instance.Tiles.GetLength(1));
                     break;
                 case 1:
-                    spawnPosition.x = MapManager.Instance.Tiles.GetLength(0);
-                    spawnPosition.y = Random.Range(0, MapManager.Instance.Tiles.GetLength(1));
+                    startCoordinate.x = MapManager.Instance.Tiles.GetLength(0);
+                    startCoordinate.y = Random.Range(0, MapManager.Instance.Tiles.GetLength(1));
                     break;
                 case 2:
-                    spawnPosition.x = Random.Range(0, MapManager.Instance.Tiles.GetLength(0));
-                    spawnPosition.y = 0;
+                    startCoordinate.x = Random.Range(0, MapManager.Instance.Tiles.GetLength(0));
+                    startCoordinate.y = 0;
                     break;
                 case 3:
-                    spawnPosition.x = Random.Range(0, MapManager.Instance.Tiles.GetLength(0));
-                    spawnPosition.y = MapManager.Instance.Tiles.GetLength(1);
+                    startCoordinate.x = Random.Range(0, MapManager.Instance.Tiles.GetLength(0));
+                    startCoordinate.y = MapManager.Instance.Tiles.GetLength(1);
                     break;
             }
         }
-        while (!CheckFreeCoordinate(spawnPosition));
+        while (!CheckFreeCoordinate(startCoordinate));
 
         // 해적 오브젝트 생성
         GameObject pirateObject = Instantiate(_piratePrefab);
@@ -81,27 +113,10 @@ public class PirateManager : SingletonBehaviour<PirateManager>
         PirateController pirateController = pirateObject.GetComponent<PirateController>();
         _pirates.Add(pirateController);
 
-        // 해적 목표 지정
-        Vector2Int[] neighbors = HexaUtility.GetNeighbors(new Vector2Int(MapManager.Instance.Tiles.GetLength(0) / 2, MapManager.Instance.Tiles.GetLength(1) / 2), 30);
+        pirateController.Initialize(startCoordinate, targetCoordinate);
+        _targets.Add(targetCoordinate);
 
-        int n = neighbors.Length;
-
-        while (n > 1)
-        {
-            n--;
-
-            int k = Random.Range(0, n + 1);
-            (neighbors[k], neighbors[n]) = (neighbors[n], neighbors[k]);
-        }
-
-        foreach (Vector2Int neighbor in neighbors)
-        {
-            if (MapManager.Instance.Tiles[neighbor.x, neighbor.y].IsUnderWater && CheckOceanAccessibility(neighbor))
-            {
-                pirateController.Initialize(spawnPosition, neighbor);
-                break;
-            }
-        }
+        return true;
     }
 
     /// <summary>
@@ -111,6 +126,8 @@ public class PirateManager : SingletonBehaviour<PirateManager>
     public void DespawnPirate(PirateController pirateController)
     {
         _pirates.Remove(pirateController);
+        _targets.Remove(pirateController.TargetCoordinate);
+
         Destroy(pirateController.gameObject);
     }
 

--- a/Assets/Scripts/Pirate/PirateManager.cs
+++ b/Assets/Scripts/Pirate/PirateManager.cs
@@ -34,18 +34,6 @@ public class PirateManager : SingletonBehaviour<PirateManager>
     }
     private int[,] _penalties;
 
-    private void Update()
-    {
-        //QualitySettings.vSyncCount = 0;
-        //Application.targetFrameRate = 30;
-
-        // TEST
-        if (Input.GetKeyDown(KeyCode.P))
-        {
-            SpawnPirate();
-        }
-    }
-
     /// <summary>
     /// 해적을 생성한다.
     /// </summary>

--- a/Assets/Scripts/Pirate/PirateManager.cs.meta
+++ b/Assets/Scripts/Pirate/PirateManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 622fdf75f20d7df419be13942ca7185d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Structures/ScriptableObjects/Fortress.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Fortress.asset
@@ -40,8 +40,8 @@ MonoBehaviour:
   RequireOcean: 0
   WoodCost: 2
   StoneCost: 0
-  Radius: 3
-  MaxHappiness: 100
-  IncreaseSpeed: 10
-  DecreaseSpeed: 5
-  TimeToProduce: 0
+  Radius: 6
+  MaxHappiness: 0
+  IncreaseSpeed: 0
+  DecreaseSpeed: 0
+  TimeToProduce: 3

--- a/Assets/Scripts/Structures/ScriptableObjects/House.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/House.asset
@@ -27,8 +27,7 @@ MonoBehaviour:
     stone: 0
     cotton: 0
     clothe: 2
-    efficiencyBonus: 0
-    radiusBonus: 0
+    rangeBonus: 0
   Produces:
     population: 1
     fish: 0
@@ -37,8 +36,7 @@ MonoBehaviour:
     stone: 0
     cotton: 0
     clothe: 0
-    efficiencyBonus: 0
-    radiusBonus: 0
+    rangeBonus: 0
   RequireOcean: 0
   WoodCost: 2
   StoneCost: 0

--- a/Assets/Scripts/Structures/Structure.cs
+++ b/Assets/Scripts/Structures/Structure.cs
@@ -285,6 +285,11 @@ public class ActiveProducerStructure : Structure
 
         foreach(PirateController pirate in PirateManager.Instance.Pirates)
         {
+            if (pirate.CurrentState == PirateState.Despawn || pirate.CurrentState == PirateState.Destroy)
+            {
+                continue;
+            }
+
             if (HexaUtility.GetDistance(_tile.Coordinate, pirate.CurrentCoordinate) <= _structureData.Radius)
             {
                 if (pirate.IsUnderAttack)

--- a/Assets/Scripts/Structures/Structure.cs
+++ b/Assets/Scripts/Structures/Structure.cs
@@ -216,13 +216,16 @@ public class ActiveProducerStructure : Structure
 
     public override void OnUpdate()
     {
-        if (_currentState != StructureState.Disabled)
+        if (_currentState == StructureState.Enabled)
         {
             _elapsed += Time.deltaTime;
 
             if (_elapsed > _structureData.TimeToProduce)
             {
-                _elapsed -= _structureData.TimeToProduce;
+                if (_structureData.StructureType != StructureType.Fortress)
+                {
+                    _elapsed -= _structureData.TimeToProduce;
+                }
 
                 switch (_structureData.StructureType)
                 {
@@ -235,9 +238,17 @@ public class ActiveProducerStructure : Structure
                     case StructureType.Quarry:
                         GameManager.Instance.CurrentStones += 1;
                         break;
+                    case StructureType.Fortress:
+                        if (AttackPirate())
+                        {
+                            _elapsed -= _structureData.TimeToProduce;
+                        }
+                        else
+                        {
+                            _elapsed = _structureData.TimeToProduce;
+                        }
+                        break;
                 }
-
-                Debug.Log("Produced Something");
             }
         }
     }
@@ -260,6 +271,55 @@ public class ActiveProducerStructure : Structure
 
             _currentState = StructureState.Disabled;
             _tile.RemoveFromProviders();
+        }
+    }
+
+    /// <summary>
+    /// 범위 안에 들어온 해적을 공격한다. 다른 요새로부터 공격을 받고 있지 않은 해적을 우선시한다.
+    /// </summary>
+    /// <returns>공격 여부</returns>
+    private bool AttackPirate()
+    {
+        PirateController targetPirate = null;
+        PirateController pirateAlreadyUnderAttack = null;
+
+        foreach(PirateController pirate in PirateManager.Instance.Pirates)
+        {
+            if (HexaUtility.GetDistance(_tile.Coordinate, pirate.CurrentCoordinate) <= _structureData.Radius)
+            {
+                if (pirate.IsUnderAttack)
+                {
+                    pirateAlreadyUnderAttack = pirate;
+                }
+                else
+                {
+                    targetPirate = pirate;
+                }
+            }
+        }
+        
+        if (targetPirate == null)
+        {
+            targetPirate = pirateAlreadyUnderAttack;
+        }
+
+        if (targetPirate == null)
+        {
+            return false;
+        }
+        else
+        {
+            Vector3 fortressPosition = HexaUtility.GetWorldCoordinate(_tile.Coordinate);
+            fortressPosition.y = MapManager.Instance.OceanLevel;
+
+            Vector3 piratePosition = (HexaUtility.GetWorldCoordinate(targetPirate.GetFutureCoordinate(0)) + HexaUtility.GetWorldCoordinate(targetPirate.GetFutureCoordinate(1))) / 2.0f;
+            piratePosition.y = MapRenderer.Instance.OceanHeight;
+
+            targetPirate.StartAttackPirate();
+
+            PirateManager.Instance.SpawnCannonball(fortressPosition, piratePosition, targetPirate);
+
+            return true;
         }
     }
 }

--- a/Assets/Scripts/Structures/StructureManager.cs
+++ b/Assets/Scripts/Structures/StructureManager.cs
@@ -76,7 +76,6 @@ public class StructureManager : SingletonBehaviour<StructureManager>
         {
             case StructureType.House:
             case StructureType.Market:
-            case StructureType.Fortress:
                 return true;
 
             default:
@@ -96,6 +95,7 @@ public class StructureManager : SingletonBehaviour<StructureManager>
             case StructureType.TownHall:
             case StructureType.LumberCamp:
             case StructureType.Quarry:
+            case StructureType.Fortress:
                 return true;
 
             default:

--- a/Assets/Scripts/UI/TileInfoUI.cs
+++ b/Assets/Scripts/UI/TileInfoUI.cs
@@ -21,6 +21,7 @@ public class TileInfoUI : MonoBehaviour
     [SerializeField] private EventTrigger _happinessInfo;
     [SerializeField] private EventTrigger _timeToProduceInfo;
     [SerializeField] private EventTrigger _researchInfo;
+    [SerializeField] private EventTrigger _fortressInfo;
     [SerializeField] private Slider _gaugeSlider;
     [SerializeField] private TMP_Text _gaugeText;
 
@@ -93,6 +94,7 @@ public class TileInfoUI : MonoBehaviour
         UIManager.Instance.AddHoverEvent(_happinessInfo, "language_label", "language_label", HoverDirection.TopRight);
         UIManager.Instance.AddHoverEvent(_timeToProduceInfo, "language_label", "language_label", HoverDirection.TopRight);
         UIManager.Instance.AddHoverEvent(_researchInfo, "language_label", "language_label", HoverDirection.TopRight);
+        UIManager.Instance.AddHoverEvent(_fortressInfo, "language_label", "language_label", HoverDirection.TopRight);
         UIManager.Instance.AddHoverEvent(_researchButtonInfo, "language_label", "language_label", HoverDirection.TopRight);
         UIManager.Instance.AddHoverEvent(_destroyButtonInfo, "language_label", "language_label", HoverDirection.TopRight);
 
@@ -224,8 +226,19 @@ public class TileInfoUI : MonoBehaviour
                 _happinessInfo.gameObject.SetActive(false);
                 _timeToProduceInfo.gameObject.SetActive(false);
                 _researchInfo.gameObject.SetActive(true);
+                _fortressInfo.gameObject.SetActive(false);
 
                 _researchButton.gameObject.SetActive(true);
+            }
+            // 요새인 경우
+            else if (_currentTile.Structure.StructureData.StructureType == StructureType.Fortress)
+            {
+                _happinessInfo.gameObject.SetActive(false);
+                _timeToProduceInfo.gameObject.SetActive(false);
+                _researchInfo.gameObject.SetActive(false);
+                _fortressInfo.gameObject.SetActive(true);
+
+                _researchButton.gameObject.SetActive(false);
             }
             // 그 외 건물
             else
@@ -233,6 +246,7 @@ public class TileInfoUI : MonoBehaviour
                 _happinessInfo.gameObject.SetActive(false);
                 _timeToProduceInfo.gameObject.SetActive(true);
                 _researchInfo.gameObject.SetActive(false);
+                _fortressInfo.gameObject.SetActive(false);
 
                 _researchButton.gameObject.SetActive(false);
             }

--- a/Assets/Scripts/Utility/HexaUtility.cs
+++ b/Assets/Scripts/Utility/HexaUtility.cs
@@ -52,33 +52,22 @@ public class HexaUtility
     /// <returns>이웃 좌표들</returns>
     public static Vector2Int[] GetNeighbors(Vector2Int i, int n)
     {
-        List<Vector2Int> neighbors = new List<Vector2Int>();
-        neighbors.Add(i);
+        List<Vector2Int> results = new List<Vector2Int>();
+        Vector3Int center = OddQToCube(i);
 
-        int currentDistance = 0;
-        int searchLow = 0, searchHigh = 0;
-
-        while (currentDistance < n)
+        for (int q = -n; q <= n; q++)
         {
-            int count = 0;
-            for (; searchLow <= searchHigh; searchLow++)
+            for (int r = -n; r <= n; r++)
             {
-                for (int k = 0; k < 6; k++)
+                int s = -q - r;
+                if (s >= -n && s <= n)
                 {
-                    Vector2Int neighbor = GetNeighbor(neighbors[searchLow], (TileNeighbor)k);
-                    if (!neighbors.Contains(neighbor))
-                    {
-                        neighbors.Add(neighbor);
-                        count++;
-                    }
+                    Vector3Int neighbor = new Vector3Int(center.x + q, center.y + r, center.z + s);
+                    results.Add(CubeToOddQ(neighbor));
                 }
             }
-            searchHigh += count;
-
-            currentDistance++;
         }
-
-        return neighbors.ToArray();
+        return results.ToArray();
     }
 
     /// <summary>
@@ -89,34 +78,10 @@ public class HexaUtility
     /// <returns>거리 </returns>
     public static int GetDistance(Vector2Int a, Vector2Int b)
     {
-        if (a == b) return 0;
+        Vector3Int ta = OddQToCube(a);
+        Vector3Int tb = OddQToCube(b);
 
-        int distance = 0;
-
-        List<Vector2Int> neighbors = new List<Vector2Int>();
-        neighbors.Add(a);
-
-        int temp = -1;
-
-        while (true)
-        {
-            temp += 1;
-
-            for (int k = 0; k < 6; k++)
-            {
-                distance++;
-
-                Vector2Int neighbor = GetNeighbor(neighbors[temp], (TileNeighbor)k);
-                if (neighbor == b)
-                {
-                    return distance;
-                }
-                else if (!neighbors.Contains(neighbor))
-                {
-                    neighbors.Add(neighbor);
-                }
-            }
-        }
+        return Mathf.Max(Mathf.Abs(ta.x - tb.x), Mathf.Abs(ta.y - tb.y), Mathf.Abs(ta.z - tb.z));
     }
 
     /// <summary>
@@ -171,4 +136,26 @@ public class HexaUtility
 
         return retCoord;
     }
+
+    /// <summary>
+    /// OddQ 형식의 좌표를 Cube 형식으로 변환한다.
+    /// </summary>
+    public static Vector3Int OddQToCube(Vector2Int i)
+    {
+        int q = i.x;
+        int r = i.y - (i.x - (i.x & 1)) / 2;
+        int s = -q - r;
+        return new Vector3Int(q, r, s);
+    }
+
+    /// <summary>
+    /// Cube 형식의 좌표를 OddQ 형식으로 변환한다.
+    /// </summary>
+    public static Vector2Int CubeToOddQ(Vector3Int i)
+    {
+        int col = i.x;
+        int row = i.y + (i.x - (i.x & 1)) / 2;
+        return new Vector2Int(col, row);
+    }
+
 }

--- a/Assets/Scripts/Utility/HexaUtility.cs
+++ b/Assets/Scripts/Utility/HexaUtility.cs
@@ -75,13 +75,59 @@ public class HexaUtility
     /// </summary>
     /// <param name="a">좌표 1</param>
     /// <param name="b">좌표 2</param>
-    /// <returns>거리 </returns>
+    /// <returns>거리</returns>
     public static int GetDistance(Vector2Int a, Vector2Int b)
     {
         Vector3Int ta = OddQToCube(a);
         Vector3Int tb = OddQToCube(b);
 
         return Mathf.Max(Mathf.Abs(ta.x - tb.x), Mathf.Abs(ta.y - tb.y), Mathf.Abs(ta.z - tb.z));
+    }
+
+    /// <summary>
+    /// 두 좌표를 연결하는 직선 경로를 계산한다.
+    /// </summary>
+    /// <param name="a">좌표 1</param>
+    /// <param name="b">좌표 2</param>
+    /// <returns>직선 경로에 포함되는 타일</returns>
+    public static Vector2Int[] GetLine(Vector2Int a, Vector2Int b)
+    {
+        int n = GetDistance(a, b);
+
+        Vector3Int ta = OddQToCube(a);
+        Vector3Int tb = OddQToCube(b);
+
+        List<Vector2Int> results = new List<Vector2Int>();
+
+        for (int i = 0; i <= n; i++)
+        {
+            Vector3 floatingCube = new Vector3(Mathf.Lerp(ta.x, tb.x, (float)i / (float)n), Mathf.Lerp(ta.y, tb.y, (float)i / (float)n), Mathf.Lerp(ta.z, tb.z, (float)i / (float)n));
+
+            float q = Mathf.Round(floatingCube.x);
+            float r = Mathf.Round(floatingCube.y);
+            float s = Mathf.Round(floatingCube.z);
+
+            float dq = Mathf.Abs(q - floatingCube.x);
+            float dr = Mathf.Abs(r - floatingCube.y);
+            float ds = Mathf.Abs(s - floatingCube.z);
+
+            if (dq > dr && dq > ds)
+            {
+                q = -r - s;
+            }
+            else if (dr > ds)
+            {
+                r = -q - s;
+            }
+            else
+            {
+                s = -q - r;
+            }
+
+            results.Add(CubeToOddQ(new Vector3Int((int)q, (int)r, (int)s)));
+        }
+
+        return results.ToArray();
     }
 
     /// <summary>

--- a/Assets/Scripts/Utility/PriorityQueue.cs
+++ b/Assets/Scripts/Utility/PriorityQueue.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine.Rendering.UI;
+
+public class PriorityQueue<T, S> where S : IComparable<S>
+{
+    public int Count { get => _pq.Count; }
+
+    private List<(T, S)> _pq;
+
+    public PriorityQueue() {
+        _pq = new List<(T, S)>();
+    }
+
+    public void Enqueue(T element, S priority)
+    {
+        _pq.Add((element, priority));
+
+        int current = _pq.Count - 1;
+
+        while (current > 0)
+        {
+            int parent = (current - 1) / 2;
+
+            if (_pq[current].Item2.CompareTo(_pq[parent].Item2) > 0)
+            {
+                break;
+            }
+
+            (_pq[current], _pq[parent]) = (_pq[parent], _pq[current]);
+            current = parent;
+        }
+    }
+
+    public T Dequeue()
+    {
+        if (_pq.Count == 0)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        (T, S) result = _pq[0];
+
+        _pq[0] = _pq[_pq.Count - 1];
+        _pq.RemoveAt(_pq.Count - 1);
+
+        int current = 0;
+
+        while (true)
+        {
+            int left = current * 2 + 1;
+            int right = current * 2 + 2;
+
+            int smallest = current;
+
+            if (left < _pq.Count && _pq[left].Item2.CompareTo(_pq[smallest].Item2) < 0)
+            {
+                smallest = left;
+            }
+
+            if (right < _pq.Count && _pq[right].Item2.CompareTo(_pq[smallest].Item2) < 0)
+            {
+                smallest = right;
+            }
+
+            if (smallest == current)
+            {
+                break;
+            }
+
+            (_pq[current], _pq[smallest]) = (_pq[smallest], _pq[current]);
+            current = smallest;
+        }
+
+        return result.Item1;
+    }
+}

--- a/Assets/Scripts/Utility/PriorityQueue.cs.meta
+++ b/Assets/Scripts/Utility/PriorityQueue.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f68a41a4ba0b1e34ab0e9529b084c1fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### 관련 이슈
- #5

### 구현 사항
- 해적선이 제대로 렌더링되도록 일부 셰이더의 `Depth Write` 설정을 변경했습니다.
- 해적을 소비형 건물에서 능동 생산형 건물로 변경하고, 범위를 6으로 늘렸습니다.
- `GameManager`
  - 해적 스폰 로직을 추가했습니다.
  - 일정 시간마다 정해진 확률로 스폰을 시도하고, 스폰에 실패하면 확률이 증가합니다.
- `MapManager`
  - 해수면이 상승할 때마다 해적선 경로 계산에 쓰이는 페널티를 갱신하도록 했습니다.
- `MapRenderer`
  - 게임이 일시정지 중일 때는 해수면 상승 애니메이션이 재생되지 않도록 했습니다.
- `PirateManager`
  - 게임 내 모든 해적을 관리합니다.
  - `bool SpawnPirate()`: 임의의 위치에 해적을 스폰합니다. 실패 시 `false`를 반환합니다.
  - `void DespawnPirate(PirateController)`: 주어진 해적을 디스폰합니다.
  - `void UpdatePenalties()`: 경로 계산 시 사용할 페널티 값을 갱신합니다.
  - `void SpawnCannonball(Vector3, Vector3, PirateController)`: 대포알을 스폰합니다.
- `PirateController`
  - 개별 해적을 관리합니다.
  - 상태 기계 형식으로 현재 상태를 관리하고 필요한 로직을 수행합니다.
    - `Move`: 목표 위치로 이동합니다.  다른 해적과 부딪히면 경로를 다시 계산합니다.
    - `FirstAttack`, `SecondAttack`, `ThirdAttack`: 주변의 타일을 공격합니다.
    - `Despawn`: 플레이어의 연구 포인트를 감소시킵니다.
    - `Despawn`이나 `Destroy` 상태가 아닐 때 체력이 0이 되면 해적을 파괴합니다.
  - 경로는 A* 알고리즘을 통해 계산합니다.
  - `void Initialize(Vector2Int, Vector2Int, bool)`: 해적을 초기화합니다.
  - `Vector2Int GetFutureCoordinate(int)`: 접근 예정 타일을 반환합니다.
  - `void StartAttackPirate()`: 현재 해적을 타겟으로 지정합니다.
  - `void EndAttackPirate()`: 현재 해적에 대한 공격을 종료하고, 체력을 감소시킵니다.
- `CannonballController`
  - 개별 대포알을 관리합니다.
  - `void Initialize(Vector3, Vector3, PirateController)`: 대포알을 초기화합니다.
- `ActiveProducerStructure`
  - 요새의 공격 매커니즘을 구현했습니다.
  - 대포알이 준비되면, 범위 내 해적 중 공격 받고 있지 않은 것을 우선으로 공격합니다.
- `TileInfoUI`
  - 요새 정보에 쓰일 게이지 툴팁을 추가했습니다.
- `HexaUtility`
  - 일부 알고리즘을 최적화했습니다.
  - `Vector2Int[] GetLine(Vector2Int, Vector2Int)`: 두 좌표를 직선으로 연결하는 타일들을 반환합니다.
- `PriorityQueue`
  - 우선순위 큐를 구현했습니다.