### PR TITLE
건물 렌더링 로직 개선

### DIFF
--- a/Assets/Prefabs/Structures/Disabled.prefab
+++ b/Assets/Prefabs/Structures/Disabled.prefab
@@ -1,0 +1,107 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &9073670328388804027
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7434986082395353156}
+  - component: {fileID: 5036588224202421510}
+  - component: {fileID: 8900816372983775420}
+  - component: {fileID: 4046614497230479910}
+  m_Layer: 0
+  m_Name: Disabled
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7434986082395353156
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073670328388804027}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5036588224202421510
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073670328388804027}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8900816372983775420
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073670328388804027}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 95c1a5fa9cb06a144ab30c19cbb88ec5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &4046614497230479910
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073670328388804027}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Structures/Disabled.prefab.meta
+++ b/Assets/Prefabs/Structures/Disabled.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a46c7eaf31617894995e6b5013693633
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Tile.cs
+++ b/Assets/Scripts/Data/Tile.cs
@@ -86,6 +86,12 @@ public class Tile
     }
     private List<Structure> _providers = new List<Structure>();
 
+    public int RandomIndex
+    {
+        get => _randomIndex;
+    }
+    private int _randomIndex;
+
     /// <summary>
     /// 생성자
     /// </summary>
@@ -95,6 +101,8 @@ public class Tile
     {
         _coordinate = coordinate;
         _height = height;
+
+        _randomIndex = RandomUtility.GetRandomNoise(_coordinate.x, _coordinate.y, 1024);
     }
 
     /// <summary>
@@ -127,6 +135,7 @@ public class Tile
 
             // 주변 타일의 자원 제공자에 현재 건물을 추가
             _structure.Initialize();
+            _structure.OnRenderStart();
         }
 
         UIManager.Instance.UpdateTileInfo(_coordinate);
@@ -159,7 +168,9 @@ public class Tile
             // 주변 타일의 자원 제공자에서 현재 건물을 제거
             RemoveFromProviders();
 
+            _structure.OnRenderEnd();
             _structure = null;
+
             MapRenderer.Instance.UpdateTile(_coordinate);
         }
 

--- a/Assets/Scripts/Data/Tile.cs
+++ b/Assets/Scripts/Data/Tile.cs
@@ -135,7 +135,7 @@ public class Tile
 
             // 주변 타일의 자원 제공자에 현재 건물을 추가
             _structure.Initialize();
-            _structure.OnRenderStart();
+            _structure.OnRenderUpdate();
         }
 
         UIManager.Instance.UpdateTileInfo(_coordinate);

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -24,7 +24,6 @@ public class GameManager : SingletonBehaviour<GameManager>
 
     [SerializeField] private Animator _dayNightAnimator;
 
-    private float _elapsedTime = 480.0f / DAY_SPEED;
     private float _riseCooldown = OCEAN_RISE_PERIOD;
     private float _researchCooldown = 0.0f;
 
@@ -59,6 +58,15 @@ public class GameManager : SingletonBehaviour<GameManager>
         get => _currentDay;
     }
     private int _currentDay = 1;
+
+    /// <summary>
+    /// 오늘 하루를 기준으로 현재 시간
+    /// </summary>
+    public float CurrentTime
+    {
+        get => _currentTime;
+    }
+    private float _currentTime = 480.0f;
 
     /// <summary>
     /// 해수면 상승으로부터 지난 시간
@@ -141,10 +149,15 @@ public class GameManager : SingletonBehaviour<GameManager>
             return;
         }
 
-        _elapsedTime += Time.deltaTime;
-        _currentDay = (Mathf.RoundToInt(_elapsedTime * DAY_SPEED) / 1440) % 99 + 1;
+        _currentTime += Time.deltaTime * DAY_SPEED;
 
-        _dayNightAnimator.Play("Cycle", 0, (Mathf.RoundToInt(_elapsedTime * DAY_SPEED) % 1440) / 1440.0f);
+        if (_currentTime > 1440.0f)
+        {
+            _currentTime -= 1440.0f;
+            _currentDay = _currentDay % 99 + 1;
+        }
+
+        _dayNightAnimator.Play("Cycle", 0, _currentTime / 1440.0f);
 
         // 연구 쿨타임 처리
         if (!_isResearchable)

--- a/Assets/Scripts/Map/MapGenerator.cs
+++ b/Assets/Scripts/Map/MapGenerator.cs
@@ -40,10 +40,8 @@ public class MapGenerator : SingletonBehaviour<MapGenerator>
 
         Tile[,] tiles = new Tile[w, h];
 
-        Random.InitState((int)System.DateTime.Now.Ticks);
-
-        float mapOffset = Random.Range(-50, 50);
-        float fertileOffset = Random.Range(-50, 50);
+        float offsetX = Random.Range(-50, 50);
+        float offsetY = Random.Range(-50, 50);
 
         int min = 1000;
         int max = -1000;
@@ -53,8 +51,8 @@ public class MapGenerator : SingletonBehaviour<MapGenerator>
         {
             for (int j = 0; j < h; j++)
             {
-                int height = (int)((Mathf.PerlinNoise((float)i / w * c + mapOffset, (float)j / h * c + mapOffset) +
-                    Mathf.PerlinNoise((float)i / w * c * 2f + mapOffset, (float)j / h * c * 2f + mapOffset)) * _maxHeight * 2);
+                int height = (int)((Mathf.PerlinNoise((float)i / w * c + offsetX, (float)j / h * c + offsetY) +
+                    Mathf.PerlinNoise((float)i / w * c * 2f + offsetX, (float)j / h * c * 2f + offsetY)) * _maxHeight * 2);
 
                 float t = w * w / 4f + h * h / 4f;
                 t -= (i - w / 2f) * (i - w / 2f) + (j - h / 2f) * (j - h / 2f);

--- a/Assets/Scripts/Map/MapManager.cs
+++ b/Assets/Scripts/Map/MapManager.cs
@@ -35,7 +35,7 @@ public class MapManager : SingletonBehaviour<MapManager>
 
     private void Start()
     {
-        Random.InitState(0);
+        RandomUtility.Seed = (int)System.DateTime.Now.Ticks;
 
         _tiles = GetComponent<MapGenerator>().GenerateMap(128, 128, 6f);
         GetComponent<MapRenderer>().RenderMap();

--- a/Assets/Scripts/Map/MapRenderer.cs
+++ b/Assets/Scripts/Map/MapRenderer.cs
@@ -182,12 +182,12 @@ public class MapRenderer : SingletonBehaviour<MapRenderer>
         Tile currentTile = MapManager.Instance.Tiles[x, y];
         StructureData structureData = StructureManager.Instance.GetStructureData(structureType);
 
-        Vector3 worldCoordinate = HexaUtility.GetWorldCoordinate(coordinate);
-        worldCoordinate.y = currentTile.Height + 1;
+        Vector3 position = HexaUtility.GetWorldCoordinate(coordinate);
+        position.y = currentTile.Height + 1.0f;
 
         _sunkenStructures[x, y] = structureType;
-        _sunkenStructureObjects[x, y] = structureData.SunkenStructurePrefab[currentTile.RandomIndex % structureData.SunkenStructurePrefab.Length];
-        _sunkenStructureObjects[x, y].transform.position = worldCoordinate;
+        _sunkenStructureObjects[x, y] = Instantiate(structureData.SunkenStructurePrefab[currentTile.RandomIndex % structureData.SunkenStructurePrefab.Length]);
+        _sunkenStructureObjects[x, y].transform.position = position;
     }
 
     /// <summary>

--- a/Assets/Scripts/Map/MapRenderer.cs
+++ b/Assets/Scripts/Map/MapRenderer.cs
@@ -25,14 +25,12 @@ public class MapRenderer : SingletonBehaviour<MapRenderer>
     [SerializeField] Material _invalidMaterial;
 
     private GameObject _tileHolder;         // 모든 타일 오브젝트의 부모 (정리용)
-    private GameObject _structureHolder;    // 모든 건물 오브젝트의 부모 (정리용)
     private GameObject _rangeHolder;        // 모든 효과 범위 오브젝트의 부모
 
     private GameObject[][,] _meshObjects = new GameObject[32][,];   // 모든 타일 오브젝트 [height][w, h]
-    private GameObject[,] _structureObjects;                        // 모든 건물 오브젝트
+    private GameObject[,] _naturalResourcesObjects;                 // 모든 천연 자원 오브젝트
 
     private Dictionary<Vector2Int, GameObject> _deckObjects;        // 모든 데크 오브젝트
-    private List<Vector2Int> _floatingStructures;                   // 건물 오브젝트 중 데크 위에 있는 것 목록
     private Dictionary<Vector2Int, GameObject> _rangeObjects;       // 모든 효과 범위 오브젝트
 
     private StructureType[,] _sunkenStructures;                     // 물에 잠긴 건물 타입
@@ -78,16 +76,14 @@ public class MapRenderer : SingletonBehaviour<MapRenderer>
         _oceanObject.transform.position = (HexaUtility.GetWorldCoordinate(new Vector2Int(0, 0)) + HexaUtility.GetWorldCoordinate(new Vector2Int(w - 1, h - 1))) / 2f + Vector3.up * (oceanLevel + 0.8f);
         _oceanObject.transform.localScale = Vector3.one * 100f;
 
-        _structureObjects = new GameObject[w, h];
+        _naturalResourcesObjects = new GameObject[w, h];
         _sunkenStructures = new StructureType[w, h];
         _sunkenStructureObjects = new GameObject[w, h];
 
         _deckObjects = new Dictionary<Vector2Int, GameObject>();
-        _floatingStructures = new List<Vector2Int>();
         _rangeObjects = new Dictionary<Vector2Int, GameObject>();
 
         _tileHolder = new GameObject("Tiles");
-        _structureHolder = new GameObject("Structures");
         _rangeHolder = new GameObject("Range");
 
         // 높이 i = 0부터 시작
@@ -122,7 +118,7 @@ public class MapRenderer : SingletonBehaviour<MapRenderer>
     }
 
     /// <summary>
-    /// 건물 및 천연 자원 렌더링을 갱신한다.
+    /// 천연 자원 렌더링을 갱신한다.
     /// </summary>
     /// <param name="coordinate">좌표</param>
     public void UpdateTile(Vector2Int coordinate)
@@ -132,52 +128,44 @@ public class MapRenderer : SingletonBehaviour<MapRenderer>
 
         Tile currentTile = MapManager.Instance.Tiles[x, y];
 
-        // 기존 렌더링 파괴
-        if (_structureObjects[x, y])
+        if (_naturalResourcesObjects[x, y] != null)
         {
-            Destroy(_structureObjects[x, y]);
-            _floatingStructures.Remove(coordinate);
-        }
-
-        // World 좌표 계산
-        Vector3 worldCoordinate = HexaUtility.GetWorldCoordinate(coordinate);
-
-        if (currentTile.IsDecked)
-        {
-            worldCoordinate.y = _oceanObject.transform.position.y;
-        }
-        else
-        {
-            worldCoordinate.y = currentTile.Height + 1;
+            Destroy(_naturalResourcesObjects[x, y]);
         }
 
         // 렌더링할 프리팹 탐색
         GameObject prefabToInstantiate = null;
 
-        if (currentTile.Structure != null)
+        if (currentTile.Structure == null)
         {
-            prefabToInstantiate = currentTile.Structure.StructureData.StructurePrefab;
-        }
-        else if (currentTile.NaturalResource == NaturalResourceType.Woods)
-        {
-            prefabToInstantiate = _woodsPrefab;
-        }
-        else if (currentTile.NaturalResource == NaturalResourceType.Stone)
-        {
-            prefabToInstantiate = _stonePrefab;
+            if (currentTile.NaturalResource == NaturalResourceType.Woods)
+            {
+                prefabToInstantiate = _woodsPrefab;
+            }
+            else if (currentTile.NaturalResource == NaturalResourceType.Stone)
+            {
+                prefabToInstantiate = _stonePrefab;
+            }
         }
 
         // 주어진 좌표에 프리팹 렌더링
         if (prefabToInstantiate != null)
         {
-            _structureObjects[x, y] = Instantiate(prefabToInstantiate, _structureHolder.transform);
-            _structureObjects[x, y].name = x + "_" + y;
-            _structureObjects[x, y].transform.position = worldCoordinate;
+            // World 좌표 계산
+            Vector3 worldCoordinate = HexaUtility.GetWorldCoordinate(coordinate);
 
-            if (currentTile.IsUnderWater)
+            if (currentTile.IsDecked)
             {
-                _floatingStructures.Add(coordinate);
+                worldCoordinate.y = _oceanObject.transform.position.y;
             }
+            else
+            {
+                worldCoordinate.y = currentTile.Height + 1;
+            }
+
+            _naturalResourcesObjects[x, y] = Instantiate(prefabToInstantiate, StructureManager.Instance.StructureHolder.transform);
+            _naturalResourcesObjects[x, y].name = x + "_" + y;
+            _naturalResourcesObjects[x, y].transform.position = worldCoordinate;
         }
     }
 
@@ -191,11 +179,14 @@ public class MapRenderer : SingletonBehaviour<MapRenderer>
         int x = coordinate.x;
         int y = coordinate.y;
 
+        Tile currentTile = MapManager.Instance.Tiles[x, y];
+        StructureData structureData = StructureManager.Instance.GetStructureData(structureType);
+
         Vector3 worldCoordinate = HexaUtility.GetWorldCoordinate(coordinate);
-        worldCoordinate.y = MapManager.Instance.Tiles[x, y].Height + 1;
+        worldCoordinate.y = currentTile.Height + 1;
 
         _sunkenStructures[x, y] = structureType;
-        _sunkenStructureObjects[x, y] = Instantiate(StructureManager.Instance.GetStructureData(structureType).SunkenStructurePrefab);
+        _sunkenStructureObjects[x, y] = structureData.SunkenStructurePrefab[currentTile.RandomIndex % structureData.SunkenStructurePrefab.Length];
         _sunkenStructureObjects[x, y].transform.position = worldCoordinate;
     }
 
@@ -205,10 +196,16 @@ public class MapRenderer : SingletonBehaviour<MapRenderer>
     /// <param name="coordinate">좌표</param>
     public void AddDeckStructure(Vector2Int coordinate)
     {
+        int x = coordinate.x;
+        int y = coordinate.y;
+
+        Tile currentTile = MapManager.Instance.Tiles[x, y];
+        StructureData structureData = StructureManager.Instance.GetStructureData(StructureType.Deck);
+
         Vector3 worldCoordinate = HexaUtility.GetWorldCoordinate(coordinate);
         worldCoordinate.y = _oceanObject.transform.position.y;
 
-        _deckObjects[coordinate] = Instantiate(StructureManager.Instance.GetStructureData(StructureType.Deck).StructurePrefab);
+        _deckObjects[coordinate] = Instantiate(structureData.DayStructurePrefab[currentTile.RandomIndex % structureData.DayStructurePrefab.Length]);
         _deckObjects[coordinate].transform.position = worldCoordinate;
     }
 
@@ -300,7 +297,7 @@ public class MapRenderer : SingletonBehaviour<MapRenderer>
 
         _previewType = structure;
 
-        _previewObject = Instantiate(StructureManager.Instance.GetStructureData(structure).StructurePrefab);
+        _previewObject = Instantiate(StructureManager.Instance.GetStructureData(structure).DayStructurePrefab[0]);
         _previewMeshRenderer = _previewObject.GetComponent<MeshRenderer>();
 
         Destroy(_previewObject.GetComponent<Collider>());
@@ -539,13 +536,6 @@ public class MapRenderer : SingletonBehaviour<MapRenderer>
                     Vector3 position = highlight.Value.transform.position;
                     position.y = Mathf.Max(_oceanObject.transform.position.y, MapManager.Instance.Tiles[highlight.Key.x, highlight.Key.y].Height + 1.0f);
                     highlight.Value.transform.position = position;
-                }
-
-                foreach (Vector2Int floatingStructure in _floatingStructures)
-                {
-                    Vector3 position = _structureObjects[floatingStructure.x, floatingStructure.y].transform.position;
-                    position.y = _oceanObject.transform.position.y;
-                    _structureObjects[floatingStructure.x, floatingStructure.y].transform.position = position;
                 }
             }
 

--- a/Assets/Scripts/Structures/ScriptableObjects/Deck.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Deck.asset
@@ -15,10 +15,18 @@ MonoBehaviour:
   StructureType: 10
   StructureImage: {fileID: 0}
   StructureNameKey: deck_title
-  StructurePrefab: {fileID: 9073670328388804027, guid: 5388a7f36f000ff4fb43b8d2af64b498, type: 3}
-  BuildingStructurePrefab: {fileID: 0}
-  DisabledStructurePrefab: {fileID: 0}
-  SunkenStructurePrefab: {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
+  DayStructurePrefab:
+  - {fileID: 9073670328388804027, guid: 5388a7f36f000ff4fb43b8d2af64b498, type: 3}
+  NightStructurePrefab:
+  - {fileID: 9073670328388804027, guid: 5388a7f36f000ff4fb43b8d2af64b498, type: 3}
+  BuildingStructurePrefab:
+  - {fileID: 0}
+  DisabledStructurePrefab:
+  - {fileID: 0}
+  SunkenStructurePrefab:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   Needs:
     population: 0
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/Deck.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Deck.asset
@@ -20,13 +20,11 @@ MonoBehaviour:
   NightStructurePrefab:
   - {fileID: 9073670328388804027, guid: 5388a7f36f000ff4fb43b8d2af64b498, type: 3}
   BuildingStructurePrefab:
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: 5388a7f36f000ff4fb43b8d2af64b498, type: 3}
   DisabledStructurePrefab:
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: 5388a7f36f000ff4fb43b8d2af64b498, type: 3}
   SunkenStructurePrefab:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: 5388a7f36f000ff4fb43b8d2af64b498, type: 3}
   Needs:
     population: 0
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/Deck.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Deck.asset
@@ -19,12 +19,10 @@ MonoBehaviour:
   - {fileID: 9073670328388804027, guid: 5388a7f36f000ff4fb43b8d2af64b498, type: 3}
   NightStructurePrefab:
   - {fileID: 9073670328388804027, guid: 5388a7f36f000ff4fb43b8d2af64b498, type: 3}
-  BuildingStructurePrefab:
-  - {fileID: 9073670328388804027, guid: 5388a7f36f000ff4fb43b8d2af64b498, type: 3}
   DisabledStructurePrefab:
-  - {fileID: 9073670328388804027, guid: 5388a7f36f000ff4fb43b8d2af64b498, type: 3}
+  - {fileID: 9073670328388804027, guid: a46c7eaf31617894995e6b5013693633, type: 3}
   SunkenStructurePrefab:
-  - {fileID: 9073670328388804027, guid: 5388a7f36f000ff4fb43b8d2af64b498, type: 3}
+  - {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
   Needs:
     population: 0
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/Farm.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Farm.asset
@@ -20,13 +20,11 @@ MonoBehaviour:
   NightStructurePrefab:
   - {fileID: 9073670328388804027, guid: 20ce9ffd9cde51048b94b1647e524758, type: 3}
   BuildingStructurePrefab:
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: 20ce9ffd9cde51048b94b1647e524758, type: 3}
   DisabledStructurePrefab:
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: 20ce9ffd9cde51048b94b1647e524758, type: 3}
   SunkenStructurePrefab:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: 20ce9ffd9cde51048b94b1647e524758, type: 3}
   Needs:
     population: 1
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/Farm.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Farm.asset
@@ -15,10 +15,18 @@ MonoBehaviour:
   StructureType: 6
   StructureImage: {fileID: 0}
   StructureNameKey: farm_title
-  StructurePrefab: {fileID: 9073670328388804027, guid: 20ce9ffd9cde51048b94b1647e524758, type: 3}
-  BuildingStructurePrefab: {fileID: 0}
-  DisabledStructurePrefab: {fileID: 0}
-  SunkenStructurePrefab: {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
+  DayStructurePrefab:
+  - {fileID: 9073670328388804027, guid: 20ce9ffd9cde51048b94b1647e524758, type: 3}
+  NightStructurePrefab:
+  - {fileID: 9073670328388804027, guid: 20ce9ffd9cde51048b94b1647e524758, type: 3}
+  BuildingStructurePrefab:
+  - {fileID: 0}
+  DisabledStructurePrefab:
+  - {fileID: 0}
+  SunkenStructurePrefab:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   Needs:
     population: 1
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/Farm.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Farm.asset
@@ -19,12 +19,10 @@ MonoBehaviour:
   - {fileID: 9073670328388804027, guid: 20ce9ffd9cde51048b94b1647e524758, type: 3}
   NightStructurePrefab:
   - {fileID: 9073670328388804027, guid: 20ce9ffd9cde51048b94b1647e524758, type: 3}
-  BuildingStructurePrefab:
-  - {fileID: 9073670328388804027, guid: 20ce9ffd9cde51048b94b1647e524758, type: 3}
   DisabledStructurePrefab:
-  - {fileID: 9073670328388804027, guid: 20ce9ffd9cde51048b94b1647e524758, type: 3}
+  - {fileID: 9073670328388804027, guid: a46c7eaf31617894995e6b5013693633, type: 3}
   SunkenStructurePrefab:
-  - {fileID: 9073670328388804027, guid: 20ce9ffd9cde51048b94b1647e524758, type: 3}
+  - {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
   Needs:
     population: 1
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/Fortress.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Fortress.asset
@@ -15,10 +15,18 @@ MonoBehaviour:
   StructureType: 9
   StructureImage: {fileID: 0}
   StructureNameKey: fortress_title
-  StructurePrefab: {fileID: 9073670328388804027, guid: f9f017a777c80e1479c4bcd7fb45bbee, type: 3}
-  BuildingStructurePrefab: {fileID: 0}
-  DisabledStructurePrefab: {fileID: 0}
-  SunkenStructurePrefab: {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
+  DayStructurePrefab:
+  - {fileID: 9073670328388804027, guid: f9f017a777c80e1479c4bcd7fb45bbee, type: 3}
+  NightStructurePrefab:
+  - {fileID: 9073670328388804027, guid: f9f017a777c80e1479c4bcd7fb45bbee, type: 3}
+  BuildingStructurePrefab:
+  - {fileID: 0}
+  DisabledStructurePrefab:
+  - {fileID: 0}
+  SunkenStructurePrefab:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   Needs:
     population: 2
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/Fortress.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Fortress.asset
@@ -19,12 +19,10 @@ MonoBehaviour:
   - {fileID: 9073670328388804027, guid: f9f017a777c80e1479c4bcd7fb45bbee, type: 3}
   NightStructurePrefab:
   - {fileID: 9073670328388804027, guid: f9f017a777c80e1479c4bcd7fb45bbee, type: 3}
-  BuildingStructurePrefab:
-  - {fileID: 9073670328388804027, guid: f9f017a777c80e1479c4bcd7fb45bbee, type: 3}
   DisabledStructurePrefab:
-  - {fileID: 9073670328388804027, guid: f9f017a777c80e1479c4bcd7fb45bbee, type: 3}
+  - {fileID: 9073670328388804027, guid: a46c7eaf31617894995e6b5013693633, type: 3}
   SunkenStructurePrefab:
-  - {fileID: 9073670328388804027, guid: f9f017a777c80e1479c4bcd7fb45bbee, type: 3}
+  - {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
   Needs:
     population: 2
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/Fortress.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Fortress.asset
@@ -20,13 +20,11 @@ MonoBehaviour:
   NightStructurePrefab:
   - {fileID: 9073670328388804027, guid: f9f017a777c80e1479c4bcd7fb45bbee, type: 3}
   BuildingStructurePrefab:
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: f9f017a777c80e1479c4bcd7fb45bbee, type: 3}
   DisabledStructurePrefab:
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: f9f017a777c80e1479c4bcd7fb45bbee, type: 3}
   SunkenStructurePrefab:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: f9f017a777c80e1479c4bcd7fb45bbee, type: 3}
   Needs:
     population: 2
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/House.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/House.asset
@@ -15,10 +15,18 @@ MonoBehaviour:
   StructureType: 1
   StructureImage: {fileID: 0}
   StructureNameKey: house_title
-  StructurePrefab: {fileID: 9073670328388804027, guid: 3f863f2fae4f9654fbb348c6087ff2e3, type: 3}
-  BuildingStructurePrefab: {fileID: 0}
-  DisabledStructurePrefab: {fileID: 0}
-  SunkenStructurePrefab: {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
+  DayStructurePrefab:
+  - {fileID: 9073670328388804027, guid: 3f863f2fae4f9654fbb348c6087ff2e3, type: 3}
+  NightStructurePrefab:
+  - {fileID: 9073670328388804027, guid: 3f863f2fae4f9654fbb348c6087ff2e3, type: 3}
+  BuildingStructurePrefab:
+  - {fileID: 0}
+  DisabledStructurePrefab:
+  - {fileID: 0}
+  SunkenStructurePrefab:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   Needs:
     population: 0
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/House.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/House.asset
@@ -20,13 +20,11 @@ MonoBehaviour:
   NightStructurePrefab:
   - {fileID: 9073670328388804027, guid: 3f863f2fae4f9654fbb348c6087ff2e3, type: 3}
   BuildingStructurePrefab:
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: 3f863f2fae4f9654fbb348c6087ff2e3, type: 3}
   DisabledStructurePrefab:
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: 3f863f2fae4f9654fbb348c6087ff2e3, type: 3}
   SunkenStructurePrefab:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: 3f863f2fae4f9654fbb348c6087ff2e3, type: 3}
   Needs:
     population: 0
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/House.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/House.asset
@@ -19,12 +19,10 @@ MonoBehaviour:
   - {fileID: 9073670328388804027, guid: 3f863f2fae4f9654fbb348c6087ff2e3, type: 3}
   NightStructurePrefab:
   - {fileID: 9073670328388804027, guid: 3f863f2fae4f9654fbb348c6087ff2e3, type: 3}
-  BuildingStructurePrefab:
-  - {fileID: 9073670328388804027, guid: 3f863f2fae4f9654fbb348c6087ff2e3, type: 3}
   DisabledStructurePrefab:
-  - {fileID: 9073670328388804027, guid: 3f863f2fae4f9654fbb348c6087ff2e3, type: 3}
+  - {fileID: 9073670328388804027, guid: a46c7eaf31617894995e6b5013693633, type: 3}
   SunkenStructurePrefab:
-  - {fileID: 9073670328388804027, guid: 3f863f2fae4f9654fbb348c6087ff2e3, type: 3}
+  - {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
   Needs:
     population: 0
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/LumberCamp.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/LumberCamp.asset
@@ -20,13 +20,11 @@ MonoBehaviour:
   NightStructurePrefab:
   - {fileID: 9073670328388804027, guid: 2346b0deb54982744b9b629d8bc7fcea, type: 3}
   BuildingStructurePrefab:
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: 2346b0deb54982744b9b629d8bc7fcea, type: 3}
   DisabledStructurePrefab:
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: 2346b0deb54982744b9b629d8bc7fcea, type: 3}
   SunkenStructurePrefab:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: 2346b0deb54982744b9b629d8bc7fcea, type: 3}
   Needs:
     population: 1
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/LumberCamp.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/LumberCamp.asset
@@ -19,12 +19,10 @@ MonoBehaviour:
   - {fileID: 9073670328388804027, guid: 2346b0deb54982744b9b629d8bc7fcea, type: 3}
   NightStructurePrefab:
   - {fileID: 9073670328388804027, guid: 2346b0deb54982744b9b629d8bc7fcea, type: 3}
-  BuildingStructurePrefab:
-  - {fileID: 9073670328388804027, guid: 2346b0deb54982744b9b629d8bc7fcea, type: 3}
   DisabledStructurePrefab:
-  - {fileID: 9073670328388804027, guid: 2346b0deb54982744b9b629d8bc7fcea, type: 3}
+  - {fileID: 9073670328388804027, guid: a46c7eaf31617894995e6b5013693633, type: 3}
   SunkenStructurePrefab:
-  - {fileID: 9073670328388804027, guid: 2346b0deb54982744b9b629d8bc7fcea, type: 3}
+  - {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
   Needs:
     population: 1
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/LumberCamp.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/LumberCamp.asset
@@ -15,10 +15,18 @@ MonoBehaviour:
   StructureType: 3
   StructureImage: {fileID: 0}
   StructureNameKey: lumber_camp_title
-  StructurePrefab: {fileID: 9073670328388804027, guid: 2346b0deb54982744b9b629d8bc7fcea, type: 3}
-  BuildingStructurePrefab: {fileID: 0}
-  DisabledStructurePrefab: {fileID: 0}
-  SunkenStructurePrefab: {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
+  DayStructurePrefab:
+  - {fileID: 9073670328388804027, guid: 2346b0deb54982744b9b629d8bc7fcea, type: 3}
+  NightStructurePrefab:
+  - {fileID: 9073670328388804027, guid: 2346b0deb54982744b9b629d8bc7fcea, type: 3}
+  BuildingStructurePrefab:
+  - {fileID: 0}
+  DisabledStructurePrefab:
+  - {fileID: 0}
+  SunkenStructurePrefab:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   Needs:
     population: 1
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/Market.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Market.asset
@@ -19,14 +19,10 @@ MonoBehaviour:
   - {fileID: 9073670328388804027, guid: cbc271c5e239a2242b172dd08e69d517, type: 3}
   NightStructurePrefab:
   - {fileID: 9073670328388804027, guid: cbc271c5e239a2242b172dd08e69d517, type: 3}
-  BuildingStructurePrefab:
-  - {fileID: 0}
   DisabledStructurePrefab:
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: a46c7eaf31617894995e6b5013693633, type: 3}
   SunkenStructurePrefab:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
   Needs:
     population: 2
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/Market.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Market.asset
@@ -15,10 +15,18 @@ MonoBehaviour:
   StructureType: 2
   StructureImage: {fileID: 0}
   StructureNameKey: market_title
-  StructurePrefab: {fileID: 9073670328388804027, guid: cbc271c5e239a2242b172dd08e69d517, type: 3}
-  BuildingStructurePrefab: {fileID: 0}
-  DisabledStructurePrefab: {fileID: 0}
-  SunkenStructurePrefab: {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
+  DayStructurePrefab:
+  - {fileID: 9073670328388804027, guid: cbc271c5e239a2242b172dd08e69d517, type: 3}
+  NightStructurePrefab:
+  - {fileID: 9073670328388804027, guid: cbc271c5e239a2242b172dd08e69d517, type: 3}
+  BuildingStructurePrefab:
+  - {fileID: 0}
+  DisabledStructurePrefab:
+  - {fileID: 0}
+  SunkenStructurePrefab:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   Needs:
     population: 2
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/Pier.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Pier.asset
@@ -20,13 +20,11 @@ MonoBehaviour:
   NightStructurePrefab:
   - {fileID: 9073670328388804027, guid: 354f11bcec99f1c4dab68c3972c18cde, type: 3}
   BuildingStructurePrefab:
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: 354f11bcec99f1c4dab68c3972c18cde, type: 3}
   DisabledStructurePrefab:
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: 354f11bcec99f1c4dab68c3972c18cde, type: 3}
   SunkenStructurePrefab:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: 354f11bcec99f1c4dab68c3972c18cde, type: 3}
   Needs:
     population: 1
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/Pier.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Pier.asset
@@ -15,10 +15,18 @@ MonoBehaviour:
   StructureType: 5
   StructureImage: {fileID: 0}
   StructureNameKey: pier_title
-  StructurePrefab: {fileID: 9073670328388804027, guid: 354f11bcec99f1c4dab68c3972c18cde, type: 3}
-  BuildingStructurePrefab: {fileID: 0}
-  DisabledStructurePrefab: {fileID: 0}
-  SunkenStructurePrefab: {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
+  DayStructurePrefab:
+  - {fileID: 9073670328388804027, guid: 354f11bcec99f1c4dab68c3972c18cde, type: 3}
+  NightStructurePrefab:
+  - {fileID: 9073670328388804027, guid: 354f11bcec99f1c4dab68c3972c18cde, type: 3}
+  BuildingStructurePrefab:
+  - {fileID: 0}
+  DisabledStructurePrefab:
+  - {fileID: 0}
+  SunkenStructurePrefab:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   Needs:
     population: 1
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/Pier.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Pier.asset
@@ -19,12 +19,10 @@ MonoBehaviour:
   - {fileID: 9073670328388804027, guid: 354f11bcec99f1c4dab68c3972c18cde, type: 3}
   NightStructurePrefab:
   - {fileID: 9073670328388804027, guid: 354f11bcec99f1c4dab68c3972c18cde, type: 3}
-  BuildingStructurePrefab:
-  - {fileID: 9073670328388804027, guid: 354f11bcec99f1c4dab68c3972c18cde, type: 3}
   DisabledStructurePrefab:
-  - {fileID: 9073670328388804027, guid: 354f11bcec99f1c4dab68c3972c18cde, type: 3}
+  - {fileID: 9073670328388804027, guid: a46c7eaf31617894995e6b5013693633, type: 3}
   SunkenStructurePrefab:
-  - {fileID: 9073670328388804027, guid: 354f11bcec99f1c4dab68c3972c18cde, type: 3}
+  - {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
   Needs:
     population: 1
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/Quarry.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Quarry.asset
@@ -19,12 +19,10 @@ MonoBehaviour:
   - {fileID: 9073670328388804027, guid: a4813711b24ee8e46bcec2031908f3cd, type: 3}
   NightStructurePrefab:
   - {fileID: 9073670328388804027, guid: a4813711b24ee8e46bcec2031908f3cd, type: 3}
-  BuildingStructurePrefab:
-  - {fileID: 9073670328388804027, guid: a4813711b24ee8e46bcec2031908f3cd, type: 3}
   DisabledStructurePrefab:
-  - {fileID: 9073670328388804027, guid: a4813711b24ee8e46bcec2031908f3cd, type: 3}
+  - {fileID: 9073670328388804027, guid: a46c7eaf31617894995e6b5013693633, type: 3}
   SunkenStructurePrefab:
-  - {fileID: 9073670328388804027, guid: a4813711b24ee8e46bcec2031908f3cd, type: 3}
+  - {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
   Needs:
     population: 1
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/Quarry.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Quarry.asset
@@ -20,13 +20,11 @@ MonoBehaviour:
   NightStructurePrefab:
   - {fileID: 9073670328388804027, guid: a4813711b24ee8e46bcec2031908f3cd, type: 3}
   BuildingStructurePrefab:
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: a4813711b24ee8e46bcec2031908f3cd, type: 3}
   DisabledStructurePrefab:
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: a4813711b24ee8e46bcec2031908f3cd, type: 3}
   SunkenStructurePrefab:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: a4813711b24ee8e46bcec2031908f3cd, type: 3}
   Needs:
     population: 1
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/Quarry.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Quarry.asset
@@ -15,10 +15,18 @@ MonoBehaviour:
   StructureType: 4
   StructureImage: {fileID: 0}
   StructureNameKey: quarry_title
-  StructurePrefab: {fileID: 9073670328388804027, guid: a4813711b24ee8e46bcec2031908f3cd, type: 3}
-  BuildingStructurePrefab: {fileID: 0}
-  DisabledStructurePrefab: {fileID: 0}
-  SunkenStructurePrefab: {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
+  DayStructurePrefab:
+  - {fileID: 9073670328388804027, guid: a4813711b24ee8e46bcec2031908f3cd, type: 3}
+  NightStructurePrefab:
+  - {fileID: 9073670328388804027, guid: a4813711b24ee8e46bcec2031908f3cd, type: 3}
+  BuildingStructurePrefab:
+  - {fileID: 0}
+  DisabledStructurePrefab:
+  - {fileID: 0}
+  SunkenStructurePrefab:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   Needs:
     population: 1
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/Restaurant.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Restaurant.asset
@@ -20,13 +20,11 @@ MonoBehaviour:
   NightStructurePrefab:
   - {fileID: 9073670328388804027, guid: 96ce34ca635194a43a8e7c2504c46519, type: 3}
   BuildingStructurePrefab:
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: 96ce34ca635194a43a8e7c2504c46519, type: 3}
   DisabledStructurePrefab:
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: 96ce34ca635194a43a8e7c2504c46519, type: 3}
   SunkenStructurePrefab:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: 96ce34ca635194a43a8e7c2504c46519, type: 3}
   Needs:
     population: 1
     fish: 1

--- a/Assets/Scripts/Structures/ScriptableObjects/Restaurant.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Restaurant.asset
@@ -19,12 +19,10 @@ MonoBehaviour:
   - {fileID: 9073670328388804027, guid: 96ce34ca635194a43a8e7c2504c46519, type: 3}
   NightStructurePrefab:
   - {fileID: 9073670328388804027, guid: 96ce34ca635194a43a8e7c2504c46519, type: 3}
-  BuildingStructurePrefab:
-  - {fileID: 9073670328388804027, guid: 96ce34ca635194a43a8e7c2504c46519, type: 3}
   DisabledStructurePrefab:
-  - {fileID: 9073670328388804027, guid: 96ce34ca635194a43a8e7c2504c46519, type: 3}
+  - {fileID: 9073670328388804027, guid: a46c7eaf31617894995e6b5013693633, type: 3}
   SunkenStructurePrefab:
-  - {fileID: 9073670328388804027, guid: 96ce34ca635194a43a8e7c2504c46519, type: 3}
+  - {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
   Needs:
     population: 1
     fish: 1

--- a/Assets/Scripts/Structures/ScriptableObjects/Restaurant.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/Restaurant.asset
@@ -15,10 +15,18 @@ MonoBehaviour:
   StructureType: 7
   StructureImage: {fileID: 0}
   StructureNameKey: restaurant_title
-  StructurePrefab: {fileID: 9073670328388804027, guid: 96ce34ca635194a43a8e7c2504c46519, type: 3}
-  BuildingStructurePrefab: {fileID: 0}
-  DisabledStructurePrefab: {fileID: 0}
-  SunkenStructurePrefab: {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
+  DayStructurePrefab:
+  - {fileID: 9073670328388804027, guid: 96ce34ca635194a43a8e7c2504c46519, type: 3}
+  NightStructurePrefab:
+  - {fileID: 9073670328388804027, guid: 96ce34ca635194a43a8e7c2504c46519, type: 3}
+  BuildingStructurePrefab:
+  - {fileID: 0}
+  DisabledStructurePrefab:
+  - {fileID: 0}
+  SunkenStructurePrefab:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   Needs:
     population: 1
     fish: 1

--- a/Assets/Scripts/Structures/ScriptableObjects/TextileMill.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/TextileMill.asset
@@ -20,13 +20,11 @@ MonoBehaviour:
   NightStructurePrefab:
   - {fileID: 9073670328388804027, guid: cf87a3ed6664d0742ae0f926e8e85d06, type: 3}
   BuildingStructurePrefab:
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: cf87a3ed6664d0742ae0f926e8e85d06, type: 3}
   DisabledStructurePrefab:
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: cf87a3ed6664d0742ae0f926e8e85d06, type: 3}
   SunkenStructurePrefab:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: cf87a3ed6664d0742ae0f926e8e85d06, type: 3}
   Needs:
     population: 1
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/TextileMill.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/TextileMill.asset
@@ -15,10 +15,18 @@ MonoBehaviour:
   StructureType: 8
   StructureImage: {fileID: 0}
   StructureNameKey: textile_mill_title
-  StructurePrefab: {fileID: 9073670328388804027, guid: cf87a3ed6664d0742ae0f926e8e85d06, type: 3}
-  BuildingStructurePrefab: {fileID: 0}
-  DisabledStructurePrefab: {fileID: 0}
-  SunkenStructurePrefab: {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
+  DayStructurePrefab:
+  - {fileID: 9073670328388804027, guid: cf87a3ed6664d0742ae0f926e8e85d06, type: 3}
+  NightStructurePrefab:
+  - {fileID: 9073670328388804027, guid: cf87a3ed6664d0742ae0f926e8e85d06, type: 3}
+  BuildingStructurePrefab:
+  - {fileID: 0}
+  DisabledStructurePrefab:
+  - {fileID: 0}
+  SunkenStructurePrefab:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   Needs:
     population: 1
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/TextileMill.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/TextileMill.asset
@@ -19,12 +19,10 @@ MonoBehaviour:
   - {fileID: 9073670328388804027, guid: cf87a3ed6664d0742ae0f926e8e85d06, type: 3}
   NightStructurePrefab:
   - {fileID: 9073670328388804027, guid: cf87a3ed6664d0742ae0f926e8e85d06, type: 3}
-  BuildingStructurePrefab:
-  - {fileID: 9073670328388804027, guid: cf87a3ed6664d0742ae0f926e8e85d06, type: 3}
   DisabledStructurePrefab:
-  - {fileID: 9073670328388804027, guid: cf87a3ed6664d0742ae0f926e8e85d06, type: 3}
+  - {fileID: 9073670328388804027, guid: a46c7eaf31617894995e6b5013693633, type: 3}
   SunkenStructurePrefab:
-  - {fileID: 9073670328388804027, guid: cf87a3ed6664d0742ae0f926e8e85d06, type: 3}
+  - {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
   Needs:
     population: 1
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/TownHall.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/TownHall.asset
@@ -19,12 +19,10 @@ MonoBehaviour:
   - {fileID: 9073670328388804027, guid: ecd9ef31f9193d34799198bf6e5f7849, type: 3}
   NightStructurePrefab:
   - {fileID: 9073670328388804027, guid: ecd9ef31f9193d34799198bf6e5f7849, type: 3}
-  BuildingStructurePrefab:
-  - {fileID: 9073670328388804027, guid: ecd9ef31f9193d34799198bf6e5f7849, type: 3}
   DisabledStructurePrefab:
-  - {fileID: 9073670328388804027, guid: ecd9ef31f9193d34799198bf6e5f7849, type: 3}
+  - {fileID: 9073670328388804027, guid: a46c7eaf31617894995e6b5013693633, type: 3}
   SunkenStructurePrefab:
-  - {fileID: 9073670328388804027, guid: ecd9ef31f9193d34799198bf6e5f7849, type: 3}
+  - {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
   Needs:
     population: 3
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/TownHall.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/TownHall.asset
@@ -20,13 +20,11 @@ MonoBehaviour:
   NightStructurePrefab:
   - {fileID: 9073670328388804027, guid: ecd9ef31f9193d34799198bf6e5f7849, type: 3}
   BuildingStructurePrefab:
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: ecd9ef31f9193d34799198bf6e5f7849, type: 3}
   DisabledStructurePrefab:
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: ecd9ef31f9193d34799198bf6e5f7849, type: 3}
   SunkenStructurePrefab:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
+  - {fileID: 9073670328388804027, guid: ecd9ef31f9193d34799198bf6e5f7849, type: 3}
   Needs:
     population: 3
     fish: 0

--- a/Assets/Scripts/Structures/ScriptableObjects/TownHall.asset
+++ b/Assets/Scripts/Structures/ScriptableObjects/TownHall.asset
@@ -15,10 +15,18 @@ MonoBehaviour:
   StructureType: 0
   StructureImage: {fileID: 0}
   StructureNameKey: town_hall_title
-  StructurePrefab: {fileID: 9073670328388804027, guid: ecd9ef31f9193d34799198bf6e5f7849, type: 3}
-  BuildingStructurePrefab: {fileID: 0}
-  DisabledStructurePrefab: {fileID: 0}
-  SunkenStructurePrefab: {fileID: 9073670328388804027, guid: b9680d7c6ee0d6545a65b86157fb3f2f, type: 3}
+  DayStructurePrefab:
+  - {fileID: 9073670328388804027, guid: ecd9ef31f9193d34799198bf6e5f7849, type: 3}
+  NightStructurePrefab:
+  - {fileID: 9073670328388804027, guid: ecd9ef31f9193d34799198bf6e5f7849, type: 3}
+  BuildingStructurePrefab:
+  - {fileID: 0}
+  DisabledStructurePrefab:
+  - {fileID: 0}
+  SunkenStructurePrefab:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   Needs:
     population: 3
     fish: 0
@@ -27,8 +35,7 @@ MonoBehaviour:
     stone: 0
     cotton: 0
     clothe: 2
-    efficiencyBonus: 0
-    radiusBonus: 0
+    rangeBonus: 0
   Produces:
     population: 0
     fish: 0
@@ -37,8 +44,7 @@ MonoBehaviour:
     stone: 0
     cotton: 0
     clothe: 0
-    efficiencyBonus: 0
-    radiusBonus: 0
+    rangeBonus: 0
   RequireOcean: 0
   WoodCost: 4
   StoneCost: 4

--- a/Assets/Scripts/Structures/Structure.cs
+++ b/Assets/Scripts/Structures/Structure.cs
@@ -42,7 +42,7 @@ public class Structure
     }
     protected Tile _tile;
 
-    private GameObject _structureObject;
+    protected GameObject _structureObject;
 
     /// <summary>
     /// 추가 범위를 고려한 효과 범위를 계산한다.
@@ -92,7 +92,16 @@ public class Structure
 
     public virtual void Initialize() { }
 
-    public virtual void OnUpdate() { }
+    public virtual void OnUpdate() {
+        if (_tile.IsUnderWater)
+        {
+            Vector3 position = _structureObject.transform.position;
+            position.y = MapRenderer.Instance.OceanHeight;
+
+            _structureObject.transform.position = position;
+        }
+    }
+
     public virtual void OnNotified() { }
 
     public virtual void OnRenderStart()
@@ -139,6 +148,8 @@ public class ConsumerStructure : Structure
 
     public override void OnUpdate()
     {
+        base.OnUpdate();
+
         // 만족도가 증가 중인 경우
         if (_currentState == StructureState.Increasing)
         {
@@ -225,6 +236,8 @@ public class ActiveProducerStructure : Structure
 
     public override void OnUpdate()
     {
+        base.OnUpdate();
+
         if (_currentState == StructureState.Enabled)
         {
             _elapsed += Time.deltaTime;

--- a/Assets/Scripts/Structures/Structure.cs
+++ b/Assets/Scripts/Structures/Structure.cs
@@ -1,11 +1,6 @@
 using UnityEngine;
 
 /// <summary>
-/// 건물의 현재 상태
-/// </summary>
-public enum StructureState { Enabled, Increasing, Decreasing, Disabled }
-
-/// <summary>
 /// 건물 종류
 /// </summary>
 public enum StructureType { TownHall, House, Market, LumberCamp, Quarry, Pier, Farm, Restaurant, TextileMill, Fortress, Deck }
@@ -27,11 +22,11 @@ public class Structure
     /// <summary>
     /// 건물 상태
     /// </summary>
-    public StructureState CurrentState
+    public bool IsEnabled
     {
-        get => _currentState;
+        get => _isEnabled;
     }
-    protected StructureState _currentState;
+    protected bool _isEnabled;
 
     /// <summary>
     /// 현재 타일
@@ -134,11 +129,17 @@ public class ConsumerStructure : Structure
     }
     private float _currentHappiness;
 
+    private bool _isIncreasing;
+
     public ConsumerStructure(StructureType type, Tile tile)
     {
         _structureData = StructureManager.Instance.GetStructureData(type);
-        _currentHappiness = _structureData.MaxHappiness;
         _tile = tile;
+
+        _currentHappiness = _structureData.MaxHappiness;
+
+        _isEnabled = true;
+        _isIncreasing = true;
     }
 
     public override void Initialize()
@@ -151,7 +152,7 @@ public class ConsumerStructure : Structure
         base.OnUpdate();
 
         // 만족도가 증가 중인 경우
-        if (_currentState == StructureState.Increasing)
+        if (_isIncreasing && _currentHappiness < _structureData.MaxHappiness)
         {
             _currentHappiness += _structureData.IncreaseSpeed * Time.deltaTime;
 
@@ -159,22 +160,22 @@ public class ConsumerStructure : Structure
             if (_currentHappiness >= _structureData.MaxHappiness)
             {
                 _currentHappiness = _structureData.MaxHappiness;
-                _currentState = StructureState.Enabled;
+                _isEnabled = true;
 
                 _tile.AddToProviders();
             }
 
         }
         // 만족도가 감소 중인 경우
-        else if (_currentState == StructureState.Decreasing)
+        else if (!_isIncreasing && _currentHappiness > 0.0f)
         {
             _currentHappiness -= _structureData.DecreaseSpeed * Time.deltaTime;
 
             // 만족도가 최소치까지 준 경우
-            if (_currentHappiness <= 0)
+            if (_currentHappiness <= 0.0f)
             {
-                _currentHappiness = 0;
-                _currentState = StructureState.Disabled;
+                _currentHappiness = 0.0f;
+                _isEnabled = false;
 
                 _tile.RemoveFromProviders();
             }
@@ -183,29 +184,7 @@ public class ConsumerStructure : Structure
 
     public override void OnNotified()
     {
-        // 요구 사항 만족 여부
-        bool satisfied = !(_tile.Resource < _structureData.Needs) && (!_structureData.RequireOcean || IsOceanNearby());
-
-        // 활성 상태에서 불만족
-        if (_currentState == StructureState.Enabled && !satisfied)
-        {
-            _currentState = StructureState.Decreasing;
-        }
-        // 비활성 상태에서 만족
-        else if (_currentState == StructureState.Disabled && satisfied)
-        {
-            _currentState = StructureState.Increasing;
-        }
-        // 증가 상태에서 불만족
-        else if (_currentState == StructureState.Increasing && !satisfied)
-        {
-            _currentState = StructureState.Decreasing;
-        }
-        // 감소 상태에서 만족
-        else if (_currentState == StructureState.Decreasing && satisfied)
-        {
-            _currentState = StructureState.Increasing;
-        }
+        _isIncreasing = !(_tile.Resource < _structureData.Needs) && (!_structureData.RequireOcean || IsOceanNearby());
     }
 }
 
@@ -238,7 +217,7 @@ public class ActiveProducerStructure : Structure
     {
         base.OnUpdate();
 
-        if (_currentState == StructureState.Enabled)
+        if (_isEnabled)
         {
             _elapsed += Time.deltaTime;
 
@@ -281,17 +260,17 @@ public class ActiveProducerStructure : Structure
         bool satisfied = !(_tile.Resource < _structureData.Needs) && (!_structureData.RequireOcean || IsOceanNearby());
 
         // 비활성 상태에서 만족
-        if (satisfied && _currentState == StructureState.Disabled)
+        if (satisfied && !_isEnabled)
         {
-            _currentState = StructureState.Enabled;
+            _isEnabled = true;
             _tile.AddToProviders();
         }
         // 활성 상태에서 불만족
-        else if (!satisfied && _currentState == StructureState.Enabled)
+        else if (!satisfied && _isEnabled)
         {
             _elapsed = 0.0f;
 
-            _currentState = StructureState.Disabled;
+            _isEnabled = false;
             _tile.RemoveFromProviders();
         }
     }
@@ -383,12 +362,12 @@ public class PassiveProducerStructure : Structure
 
         if (satisfied)
         {
-            _currentState = StructureState.Enabled;
+            _isEnabled = true;
             _tile.AddToProviders();
         }
         else
         {
-            _currentState = StructureState.Disabled;
+            _isEnabled = false;
         }
     }
 
@@ -400,9 +379,9 @@ public class PassiveProducerStructure : Structure
         if (satisfied)
         {
             // 비활성 상태에서 만족
-            if (_currentState == StructureState.Disabled)
+            if (!_isEnabled)
             {
-                _currentState = StructureState.Enabled;
+                _isEnabled = true;
                 _tile.AddToProviders();
             }
             // 식당에 공급되는 물고기 값이 변한 경우
@@ -425,9 +404,9 @@ public class PassiveProducerStructure : Structure
             }
         }
         // 활성 상태에서 불만족
-        else if (!satisfied && _currentState == StructureState.Enabled)
+        else if (!satisfied && _isEnabled)
         {
-            _currentState = StructureState.Disabled;
+            _isEnabled = false;
             _tile.RemoveFromProviders();
         }
     }

--- a/Assets/Scripts/Structures/Structure.cs
+++ b/Assets/Scripts/Structures/Structure.cs
@@ -39,6 +39,22 @@ public class Structure
 
     protected GameObject _structureObject;
 
+    protected float _daytimeStart;  // 낮의 시작
+    protected float _daytimeEnd;    // 낮의 끝
+
+    protected bool _isDaytime;      // 낮 여부
+
+    public Structure(StructureType type, Tile tile)
+    {
+        _structureData = StructureManager.Instance.GetStructureData(type);
+        _tile = tile;
+
+        _daytimeStart = 360.0f + tile.RandomIndex / 64.0f;
+        _daytimeEnd = 1110.0f - tile.RandomIndex / 64.0f;
+
+        _isDaytime = _daytimeStart < GameManager.Instance.CurrentTime && GameManager.Instance.CurrentTime < _daytimeEnd;
+    }
+
     /// <summary>
     /// 추가 범위를 고려한 효과 범위를 계산한다.
     /// </summary>
@@ -88,6 +104,16 @@ public class Structure
     public virtual void Initialize() { }
 
     public virtual void OnUpdate() {
+        // 낮 여부 확인
+        bool checkDaytime = _daytimeStart < GameManager.Instance.CurrentTime && GameManager.Instance.CurrentTime < _daytimeEnd;
+
+        if (_isDaytime != checkDaytime)
+        {
+            _isDaytime = checkDaytime;
+            OnRenderUpdate();
+        }
+
+        // 해수면 상승 처리
         if (_tile.IsUnderWater)
         {
             Vector3 position = _structureObject.transform.position;
@@ -111,7 +137,14 @@ public class Structure
 
         if (_isEnabled)
         {
-            _structureObject = GameObject.Instantiate(_structureData.DayStructurePrefab[_tile.RandomIndex % _structureData.DayStructurePrefab.Length], StructureManager.Instance.StructureHolder.transform);
+            if (_isDaytime)
+            {
+                _structureObject = GameObject.Instantiate(_structureData.DayStructurePrefab[_tile.RandomIndex % _structureData.DayStructurePrefab.Length], StructureManager.Instance.StructureHolder.transform);
+            }
+            else
+            {
+                _structureObject = GameObject.Instantiate(_structureData.NightStructurePrefab[_tile.RandomIndex % _structureData.NightStructurePrefab.Length], StructureManager.Instance.StructureHolder.transform);
+            }
         }
         else
         {
@@ -144,11 +177,8 @@ public class ConsumerStructure : Structure
 
     private bool _isIncreasing;
 
-    public ConsumerStructure(StructureType type, Tile tile)
+    public ConsumerStructure(StructureType type, Tile tile) : base(type, tile)
     {
-        _structureData = StructureManager.Instance.GetStructureData(type);
-        _tile = tile;
-
         _currentHappiness = _structureData.MaxHappiness;
 
         _isEnabled = true;
@@ -219,11 +249,7 @@ public class ActiveProducerStructure : Structure
     }
     private float _elapsed;
 
-    public ActiveProducerStructure(StructureType type, Tile tile)
-    {
-        _structureData = StructureManager.Instance.GetStructureData(type);
-        _tile = tile;
-    }
+    public ActiveProducerStructure(StructureType type, Tile tile) : base(type, tile) { }
 
     public override void Initialize()
     {
@@ -358,11 +384,7 @@ public class PassiveProducerStructure : Structure
 {
     private float _lastProduced = 0;
 
-    public PassiveProducerStructure(StructureType type, Tile tile)
-    {
-        _structureData = StructureManager.Instance.GetStructureData(type);
-        _tile = tile;
-    }
+    public PassiveProducerStructure(StructureType type, Tile tile) : base(type, tile) { }
 
     public override Resource GetEffectiveProduces()
     {

--- a/Assets/Scripts/Structures/Structure.cs
+++ b/Assets/Scripts/Structures/Structure.cs
@@ -99,12 +99,25 @@ public class Structure
 
     public virtual void OnNotified() { }
 
-    public virtual void OnRenderStart()
+    public virtual void OnRenderUpdate()
     {
+        if (_structureObject)
+        {
+            GameObject.Destroy(_structureObject);
+        }
+
         Vector3 position = HexaUtility.GetWorldCoordinate(_tile.Coordinate);
         position.y = Mathf.Max(_tile.Height + 1.0f, MapRenderer.Instance.OceanHeight);
 
-        _structureObject = GameObject.Instantiate(_structureData.DayStructurePrefab[_tile.RandomIndex % _structureData.DayStructurePrefab.Length], StructureManager.Instance.StructureHolder.transform);
+        if (_isEnabled)
+        {
+            _structureObject = GameObject.Instantiate(_structureData.DayStructurePrefab[_tile.RandomIndex % _structureData.DayStructurePrefab.Length], StructureManager.Instance.StructureHolder.transform);
+        }
+        else
+        {
+            _structureObject = GameObject.Instantiate(_structureData.DisabledStructurePrefab[_tile.RandomIndex % _structureData.DisabledStructurePrefab.Length], StructureManager.Instance.StructureHolder.transform);
+        }
+
         _structureObject.transform.position = position;
     }
 
@@ -163,6 +176,8 @@ public class ConsumerStructure : Structure
                 _isEnabled = true;
 
                 _tile.AddToProviders();
+
+                OnRenderUpdate();
             }
 
         }
@@ -178,6 +193,8 @@ public class ConsumerStructure : Structure
                 _isEnabled = false;
 
                 _tile.RemoveFromProviders();
+
+                OnRenderUpdate();
             }
         }
     }
@@ -264,6 +281,8 @@ public class ActiveProducerStructure : Structure
         {
             _isEnabled = true;
             _tile.AddToProviders();
+
+            OnRenderUpdate();
         }
         // 활성 상태에서 불만족
         else if (!satisfied && _isEnabled)
@@ -272,6 +291,8 @@ public class ActiveProducerStructure : Structure
 
             _isEnabled = false;
             _tile.RemoveFromProviders();
+
+            OnRenderUpdate();
         }
     }
 
@@ -383,6 +404,8 @@ public class PassiveProducerStructure : Structure
             {
                 _isEnabled = true;
                 _tile.AddToProviders();
+
+                OnRenderUpdate();
             }
             // 식당에 공급되는 물고기 값이 변한 경우
             else if (_structureData.StructureType == StructureType.Restaurant &&
@@ -408,6 +431,8 @@ public class PassiveProducerStructure : Structure
         {
             _isEnabled = false;
             _tile.RemoveFromProviders();
+
+            OnRenderUpdate();
         }
     }
 }

--- a/Assets/Scripts/Structures/Structure.cs
+++ b/Assets/Scripts/Structures/Structure.cs
@@ -1,11 +1,4 @@
-using System.Collections;
-using System.Collections.Generic;
-using TMPro;
-using Unity.Collections.LowLevel.Unsafe;
-using Unity.VisualScripting;
-using UnityEditor;
 using UnityEngine;
-using UnityEngine.InputSystem.XR.Haptics;
 
 /// <summary>
 /// 건물의 현재 상태
@@ -48,6 +41,8 @@ public class Structure
         get => _tile;
     }
     protected Tile _tile;
+
+    private GameObject _structureObject;
 
     /// <summary>
     /// 추가 범위를 고려한 효과 범위를 계산한다.
@@ -96,8 +91,26 @@ public class Structure
     }
 
     public virtual void Initialize() { }
+
     public virtual void OnUpdate() { }
     public virtual void OnNotified() { }
+
+    public virtual void OnRenderStart()
+    {
+        Vector3 position = HexaUtility.GetWorldCoordinate(_tile.Coordinate);
+        position.y = Mathf.Max(_tile.Height + 1.0f, MapRenderer.Instance.OceanHeight);
+
+        _structureObject = GameObject.Instantiate(_structureData.DayStructurePrefab[_tile.RandomIndex % _structureData.DayStructurePrefab.Length], StructureManager.Instance.StructureHolder.transform);
+        _structureObject.transform.position = position;
+    }
+
+    public virtual void OnRenderEnd()
+    {
+        if (_structureObject)
+        {
+            GameObject.Destroy(_structureObject);
+        }
+    }
 }
 
 /// <summary>
@@ -137,8 +150,6 @@ public class ConsumerStructure : Structure
                 _currentHappiness = _structureData.MaxHappiness;
                 _currentState = StructureState.Enabled;
 
-                //_isActive = true;
-
                 _tile.AddToProviders();
             }
 
@@ -153,8 +164,6 @@ public class ConsumerStructure : Structure
             {
                 _currentHappiness = 0;
                 _currentState = StructureState.Disabled;
-
-                //_isActive = false;
 
                 _tile.RemoveFromProviders();
             }

--- a/Assets/Scripts/Structures/StructureData.cs
+++ b/Assets/Scripts/Structures/StructureData.cs
@@ -11,10 +11,11 @@ public class StructureData : ScriptableObject
     public Sprite StructureImage;           // 건물 이미지
     public string StructureNameKey;         // 건물 이름 키
 
-    public GameObject StructurePrefab;          // 건물 프리팹
-    public GameObject BuildingStructurePrefab;  // 건설 중인 건물 프리팹
-    public GameObject DisabledStructurePrefab;  // 비활성화된 건물 프리팹
-    public GameObject SunkenStructurePrefab;    // 물에 잠긴 건물 프리팹
+    public GameObject[] DayStructurePrefab;         // 낮 건물 프리팹
+    public GameObject[] NightStructurePrefab;       // 밤 건물 프리팹
+    public GameObject[] BuildingStructurePrefab;    // 건설 중인 건물 프리팹
+    public GameObject[] DisabledStructurePrefab;    // 비활성화된 건물 프리팹
+    public GameObject[] SunkenStructurePrefab;      // 물에 잠긴 건물 프리팹
 
     public Resource Needs;      // 요구량
     public Resource Produces;   // 생산량

--- a/Assets/Scripts/Structures/StructureData.cs
+++ b/Assets/Scripts/Structures/StructureData.cs
@@ -13,7 +13,6 @@ public class StructureData : ScriptableObject
 
     public GameObject[] DayStructurePrefab;         // 낮 건물 프리팹
     public GameObject[] NightStructurePrefab;       // 밤 건물 프리팹
-    public GameObject[] BuildingStructurePrefab;    // 건설 중인 건물 프리팹
     public GameObject[] DisabledStructurePrefab;    // 비활성화된 건물 프리팹
     public GameObject[] SunkenStructurePrefab;      // 물에 잠긴 건물 프리팹
 

--- a/Assets/Scripts/Structures/StructureManager.cs
+++ b/Assets/Scripts/Structures/StructureManager.cs
@@ -17,10 +17,20 @@ public class StructureManager : SingletonBehaviour<StructureManager>
 {
     [SerializeField] private StructurePair[] _structurePairs;
 
+    /// <summary>
+    /// 모든 건물 오브젝트의 부모 (정리용)
+    /// </summary>
+    public GameObject StructureHolder
+    {
+        get => _structureHolder;
+    }
+    private GameObject _structureHolder;
+
     private Dictionary<StructureType, StructureData> _structureData;
 
-    private void OnValidate()
+    private void Start()
     {
+        _structureHolder = new GameObject("Structures");
         _structureData = new Dictionary<StructureType, StructureData>();
 
         foreach (StructurePair pair in _structurePairs)

--- a/Assets/Scripts/Structures/StructureManager.cs.meta
+++ b/Assets/Scripts/Structures/StructureManager.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -50
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Assets/Scripts/UI/TileInfoUI.cs
+++ b/Assets/Scripts/UI/TileInfoUI.cs
@@ -195,8 +195,7 @@ public class TileInfoUI : MonoBehaviour
         _titleText.UpdateTextLanguage();
 
         // !TEST: 건물 상태 확인용
-        if (_currentTile.Structure.CurrentState == StructureState.Enabled ||
-            _currentTile.Structure.CurrentState == StructureState.Increasing)
+        if (_currentTile.Structure.IsEnabled)
         {
             _structureImage.color = Color.green;
         }

--- a/Assets/Scripts/Utility/RandomUtility.cs
+++ b/Assets/Scripts/Utility/RandomUtility.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+
+/// <summary>
+/// 유사난수를 생성하는 클래스
+/// </summary>
+public class RandomUtility
+{
+    /// <summary>
+    /// 시드
+    /// </summary>
+    public static int Seed
+    {
+        get => _seed;
+        set
+        {
+            _seed = value;
+            Random.InitState(_seed);
+        }
+    }
+    private static int _seed;
+
+    /// <summary>
+    /// 2D 무작위 패턴을 생성한다.
+    /// </summary>
+    /// <param name="x">X 좌표</param>
+    /// <param name="y">Y 좌표</param>
+    /// <param name="m">최댓값</param>
+    /// <returns>[0, m)의 값</returns>
+    public static int GetRandomNoise(int x, int y, int m)
+    {
+        int hash = _seed;
+        hash = hash * 31 + x;
+        hash = hash * 31 + y;
+
+        System.Random rand = new System.Random(hash);
+        
+        return rand.Next(0, m);
+    }
+}

--- a/Assets/Scripts/Utility/RandomUtility.cs.meta
+++ b/Assets/Scripts/Utility/RandomUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4d8ecf0acd8fe3146a946522e61154ac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### 관련 이슈
- #24

### 구현 사항
- `StructureData`
  - 한 건물이 여러 모델을 사용할 수 있도록, 프리팹 필드를 배열로 바꾸었습니다.
  - 낮과 밤에 사용할 건물 프리팹을 분리하였습니다.
- `Structure`
  - 각 건물에 대한 렌더링을 본 클래스에서 처리하도록 바꾸었습니다.
  - 자식 클래스의 일부 로직을 개선하고, 필요한 경우 렌더링을 갱신하도록 하였습니다.
  - `base` 클래스에 다음 메소드를 추가했습니다.
    - `Structure(StructureType, Tile)`: 낮밤을 구분하는 기준 시간을 지정합니다.
    - `void OnUpdate()`: 낮밤에 따라 렌더링을 갱신하고, 해수면 상승 시 떠 있는 건물을 처리합니다.
    - `void OnRenderUpdate()`: 건물 렌더링을 생성하거나 갱신합니다.
    - `void OnRenderEnd()`: 건물이 파괴된 경우 렌더링을 제거합니다.
- `StructureManager`
  - 정리용 오브젝트인 `GameObject StructureHolder` 프로퍼티를 추가했습니다.
- `GameManager`
  - 오늘 하루를 기준으로 현재 시간을 나타내는 `float CurrentTime` 프로퍼티를 추가했습니다.
- `Tile`
  - 타일마다 임의 인덱스를 배정해 `int RandomIndex` 프로퍼티로 참조할 수 있게 했습니다.
    - 인덱스는 [0, 1024) 사이에서 무작위로 배정됩니다.
    - 타일마다 다른 건물 모델을 사용할 때, 낮밤의 기준 시간을 다르게 할 때 사용합니다.
- `MapRenderer`
  - 각 건물에 대한 렌더링은 `Structure` 클래스에서 담당하고, 본 클래스는 천연 자원만 처리하도록 하였습니다.
    - 단, 데크 및 물에 잠긴 건물은 여전히 본 클래스에서 처리합니다.
- `MapGenerator`
  - 가끔 맵이 이상하게 생성되던 문제를 수정했습니다.
- `RandomUtility`
  - 유사난수를 생성 및 관리하는 클래스입니다.
  - `int Seed` 프로퍼티로 현재 시드를 확인합니다. 여기서 정한 시드는 `UnityEngine.Random`에도 적용됩니다.
  - `int GetRandomNoise(int, int, int)` 메소드로 2D 좌표상에서 유사난수를 생성합니다.